### PR TITLE
No landing pads fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: |
-            -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+            -Zprofile -Zpanic_abort_tests -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
       - uses: actions-rs/grcov@v0.1
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
It seems that Rust team [removes](https://github.com/rust-lang/rust/pull/70175) a `no-landing-pads` compiler option yesterday.

And now there is an error in "Tests and coverage" job in CI workflow: "unknown debugging option: `no-landing-pads`".

I have fix it, but I am not sure of the correctness of this solution.