### PR TITLE
ExtraBlankLine checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add check: ExtraBlankLine [#180](https://github.com/dotenv-linter/dotenv-linter/pull/180) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add check: EndingBlankLine [#170](https://github.com/dotenv-linter/dotenv-linter/pull/170) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add check: Quote characters [#174](https://github.com/dotenv-linter/dotenv-linter/pull/174) ([@sourabhmarathe](https://github.com/sourabhmarathe))
 - Github Actions: Add caching in the CI workflow [#163](https://github.com/dotenv-linter/dotenv-linter/pull/163) ([@evgeniy-r](https://github.com/evgeniy-r))

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It checks `.env` files for problems that may cause the application to malfunctio
 <p>
 &nbsp;&nbsp;&nbsp;&nbsp;✅<a href="#duplicated-key">Duplicated Key</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅<a href="#ending-blank-line-will-be-available-in-v200">Ending Blank Line</a> (will be available in <a href="https://github.com/dotenv-linter/dotenv-linter/issues/172">v2.0.0</a>)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;✅<a href="#extra-blank-line-will-be-available-in-v200">Extra Blank Line</a> (will be available in <a href="https://github.com/dotenv-linter/dotenv-linter/issues/172">v2.0.0</a>)<br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅<a href="#incorrect-delimiter">Incorrect delimiter</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅<a href="#key-without-value">Key without value</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅<a href="#leading-character">Leading character</a><br />
@@ -196,6 +197,41 @@ FOO=BAR
 
 ```env
 ✅Correct
+FOO=BAR
+
+```
+
+### Extra Blank Line (will be available in [v2.0.0](https://github.com/dotenv-linter/dotenv-linter/issues/172))
+
+Detects if a file contains more than one blank line in a row.
+
+```env
+❌Wrong
+A=B
+
+
+FOO=BAR
+```
+
+```env
+❌Wrong
+A=B
+FOO=BAR
+
+
+```
+
+```env
+✅Correct
+A=B
+
+FOO=BAR
+
+```
+
+```env
+✅Correct
+A=B
 FOO=BAR
 
 ```

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -1,0 +1,89 @@
+use crate::checks::Check;
+use crate::common::*;
+
+pub(crate) struct ExtraBlankLineChecker {
+    template: &'static str,
+    name: &'static str,
+    last_blank_number: Option<usize>,
+}
+
+impl ExtraBlankLineChecker {
+    fn message(&self) -> String {
+        return format!("{}: {}", self.name, self.template);
+    }
+}
+
+impl Default for ExtraBlankLineChecker {
+    fn default() -> Self {
+        Self {
+            name: "ExtraBlankLine",
+            template: "Extra blank line detected",
+            last_blank_number: None,
+        }
+    }
+}
+
+impl Check for ExtraBlankLineChecker {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+        if !line.is_empty() {
+            return None;
+        }
+
+        if let Some(last_blank_number) = self.last_blank_number {
+            if last_blank_number + 1 == line.number {
+                return Some(Warning::new(line.clone(), self.message()));
+            }
+        }
+        self.last_blank_number = Some(line.number);
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn run_asserts(asserts: Vec<(&str, Option<&str>)>) {
+        let mut checker = ExtraBlankLineChecker::default();
+
+        for (i, assert) in asserts.iter().enumerate() {
+            let (content, message) = *assert;
+            let line = LineEntry {
+                number: i + 1,
+                file_path: PathBuf::from(".env"),
+                raw_string: String::from(content),
+            };
+            let expected = message.map(|msg| Warning::new(line.clone(), String::from(msg)));
+
+            assert_eq!(checker.run(&line), expected);
+        }
+    }
+
+    #[test]
+    fn no_blank_lines() {
+        let asserts = vec![("A=B", None), ("C=D", None)];
+
+        run_asserts(asserts);
+    }
+
+    #[test]
+    fn single_blank_line() {
+        let asserts = vec![("A=B", None), ("", None), ("C=D", None)];
+
+        run_asserts(asserts);
+    }
+
+    #[test]
+    fn two_blank_lines() {
+        let asserts = vec![
+            ("A=B", None),
+            ("", None),
+            ("", Some("ExtraBlankLine: Extra blank line detected")),
+            ("C=D", None),
+        ];
+
+        run_asserts(asserts);
+    }
+}

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -23,7 +23,7 @@ impl KeyWithoutValueChecker<'_> {
 
 impl Check for KeyWithoutValueChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
-        if !line.raw_string.contains('=') {
+        if !(line.is_empty() || line.raw_string.contains('=')) {
             Some(Warning::new(line.clone(), self.message(&line.raw_string)))
         } else {
             None
@@ -43,6 +43,17 @@ mod tests {
             number: 1,
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
+        };
+        assert_eq!(None, checker.run(&line));
+    }
+
+    #[test]
+    fn working_run_with_blank_line() {
+        let mut checker = KeyWithoutValueChecker::default();
+        let line = LineEntry {
+            number: 1,
+            file_path: PathBuf::from(".env"),
+            raw_string: String::from(""),
         };
         assert_eq!(None, checker.run(&line));
     }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -23,9 +23,10 @@ impl LeadingCharacterChecker {
 
 impl Check for LeadingCharacterChecker {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
-        if line
-            .raw_string
-            .starts_with(|c: char| c.is_alphabetic() || c == '_')
+        if line.is_empty()
+            || line
+                .raw_string
+                .starts_with(|c: char| c.is_alphabetic() || c == '_')
         {
             None
         } else {
@@ -48,6 +49,17 @@ mod tests {
             number: 1,
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
+        };
+        assert_eq!(None, checker.run(&line));
+    }
+
+    #[test]
+    fn blank_line() {
+        let mut checker = LeadingCharacterChecker::default();
+        let line = LineEntry {
+            number: 1,
+            file_path: PathBuf::from(".env"),
+            raw_string: String::from(""),
         };
         assert_eq!(None, checker.run(&line));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,16 @@ fn run_checks(fe: &FileEntry) -> io::Result<Vec<Warning>> {
     if f.seek(SeekFrom::End(-ending_seq_length)).is_ok()
         && f.read_to_string(&mut last_line)? == ending_seq_length as usize
     {
-        // We add a special LineEntry with the final character in the file
-        // for the "Ending Blank Line" check.
-        lines.push(LineEntry {
-            number: number + 1,
-            file_path: fe.path.clone(),
-            raw_string: last_line,
-        })
+        // We add an one more LineEntry with the final character in the file
+        // for the "Ending Blank Line" check if this final character is the "\n"
+        // (the latter condition is needed because of "Extra Blank Line" check at the end of file).
+        if last_line.as_str() == "\n" {
+            lines.push(LineEntry {
+                number: number + 1,
+                file_path: fe.path.clone(),
+                raw_string: last_line,
+            });
+        }
     }
 
     Ok(checks::run(lines))

--- a/tests/ending_blank_line.rs
+++ b/tests/ending_blank_line.rs
@@ -28,7 +28,7 @@ fn incorrect_files() {
         "A=B",
         "# Comment 1\n# Comment 2\n# Comment 3",
     ];
-    let expected_line_numbers = vec![4, 4, 2, 4];
+    let expected_line_numbers = vec![3, 3, 1, 3];
 
     for (i, content) in contents.iter().enumerate() {
         let testdir = TestDir::new();

--- a/tests/extra_blank_line.rs
+++ b/tests/extra_blank_line.rs
@@ -1,0 +1,69 @@
+#[allow(dead_code)]
+mod cli_common;
+
+use cli_common::TestDir;
+
+#[test]
+fn correct_files() {
+    let contents = vec![
+        "A=B\nF=BAR\n\nFOO=BAR\n",
+        "A=B\r\nF=BAR\r\n\r\nFOO=BAR\r\n",
+        "\n# comment\n\nABC=DEF\n",
+    ];
+
+    for content in contents {
+        let testdir = TestDir::new();
+        let testfile = testdir.create_testfile(".env", content);
+        let args = &[testfile.as_str()];
+
+        testdir.test_command_success_with_args(args);
+    }
+}
+
+#[test]
+fn two_blank_lines_at_the_beginning() {
+    let content = "\n\nABC=DEF\nD=BAR\nFOO=BAR\n";
+
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", content);
+    let args = &[testfile.as_str()];
+    let expected_output = format!(
+        "{}:{} ExtraBlankLine: Extra blank line detected\n",
+        testfile.shortname_as_str(),
+        2
+    );
+
+    testdir.test_command_fail_with_args(args, expected_output);
+}
+
+#[test]
+fn two_blank_lines_in_the_middle() {
+    let content = "ABC=DEF\nD=BAR\n\n\nFOO=BAR\n";
+
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", content);
+    let args = &[testfile.as_str()];
+    let expected_output = format!(
+        "{}:{} ExtraBlankLine: Extra blank line detected\n",
+        testfile.shortname_as_str(),
+        4
+    );
+
+    testdir.test_command_fail_with_args(args, expected_output);
+}
+
+#[test]
+fn two_blank_lines_at_the_end() {
+    let content = "ABC=DEF\nD=BAR\nFOO=BAR\n\n";
+
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", content);
+    let args = &[testfile.as_str()];
+    let expected_output = format!(
+        "{}:{} ExtraBlankLine: Extra blank line detected\n",
+        testfile.shortname_as_str(),
+        5
+    );
+
+    testdir.test_command_fail_with_args(args, expected_output);
+}


### PR DESCRIPTION
@mgrachev, I still have to check `\n` when adding the last line entry (we discussed this earlier) because of the special case with extra blank line at the end of file.

Any ideas?

#### ✔ Checklist:
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).