### PR TITLE
IncorrectDelimiterChecker: Replace &'static str with &'a str (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔧 Changed
 - Replace `String` with `&'a str` for `KeyWithoutValueChecker` [#177](https://github.com/dotenv-linter/dotenv-linter/pull/177) ([@mgrachev](https://github.com/mgrachev))
 - Fix docker image [#160](https://github.com/dotenv-linter/dotenv-linter/pull/160) ([@mgrachev](https://github.com/mgrachev))
+- Replace `&'static str` with `&'a str` for `IncorrectDelimiterChecker` [#191](https://github.com/dotenv-linter/dotenv-linter/pull/191) ([@DDtKey](https://github.com/DDtKey))
 
 ## [v1.2.0] - 2020-04-20
 ### 🔧 Changed

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -1,18 +1,18 @@
 use crate::checks::Check;
 use crate::common::*;
 
-pub(crate) struct IncorrectDelimiterChecker {
-    name: &'static str,
-    template: &'static str,
+pub(crate) struct IncorrectDelimiterChecker<'a> {
+    name: &'a str,
+    template: &'a str,
 }
 
-impl IncorrectDelimiterChecker {
+impl IncorrectDelimiterChecker<'_> {
     fn message(&self, key: &str) -> String {
         format!("{}: {}", self.name, self.template.replace("{}", &key))
     }
 }
 
-impl Default for IncorrectDelimiterChecker {
+impl Default for IncorrectDelimiterChecker<'_> {
     fn default() -> Self {
         Self {
             name: "IncorrectDelimiter",
@@ -21,7 +21,7 @@ impl Default for IncorrectDelimiterChecker {
     }
 }
 
-impl Check for IncorrectDelimiterChecker {
+impl Check for IncorrectDelimiterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphanumeric() && c != '_') {


### PR DESCRIPTION
Fix for #187:
Replaced `&'static str` with `&'a str` for `IncorrectDelimiterChecker`.