### PR TITLE
Updated lifetimes in EndingBlankLineChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 - Replace `&'static str` with `&'a str` for `QuoteCharacterChecker` [#198](https://github.com/dotenv-linter/dotenv-linter/pull/198) ([@duncandean](https://github.com/duncandean))
+- Replace `&'static str` with `&'a str` for `EndingBlankLineChecker` [#196](https://github.com/dotenv-linter/dotenv-linter/pull/197) ([@rossjones](https://github.com/rossjones))
 - Replace `String` with `&'a str` for `UnorderedKeyChecker` [#196](https://github.com/dotenv-linter/dotenv-linter/pull/196) ([@k0va1](https://github.com/k0va1))
 - Replace `String` with `&'a str` for `SpaceCharacterChecker` [#195](https://github.com/dotenv-linter/dotenv-linter/pull/195) ([@k0va1](https://github.com/k0va1))
 - Replace `String` with `&'a str` for `LowercaseKeyChecker` [#194](https://github.com/dotenv-linter/dotenv-linter/pull/194) ([@tisorlawan](https://github.com/tisorlawan))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 - Replace `&'static str` with `&'a str` for `QuoteCharacterChecker` [#198](https://github.com/dotenv-linter/dotenv-linter/pull/198) ([@duncandean](https://github.com/duncandean))
-- Replace `&'static str` with `&'a str` for `EndingBlankLineChecker` [#196](https://github.com/dotenv-linter/dotenv-linter/pull/197) ([@rossjones](https://github.com/rossjones))
+- Replace `&'static str` with `&'a str` for `EndingBlankLineChecker` [#197](https://github.com/dotenv-linter/dotenv-linter/pull/197) ([@rossjones](https://github.com/rossjones))
 - Replace `String` with `&'a str` for `UnorderedKeyChecker` [#196](https://github.com/dotenv-linter/dotenv-linter/pull/196) ([@k0va1](https://github.com/k0va1))
 - Replace `String` with `&'a str` for `SpaceCharacterChecker` [#195](https://github.com/dotenv-linter/dotenv-linter/pull/195) ([@k0va1](https://github.com/k0va1))
 - Replace `String` with `&'a str` for `LowercaseKeyChecker` [#194](https://github.com/dotenv-linter/dotenv-linter/pull/194) ([@tisorlawan](https://github.com/tisorlawan))

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -1,12 +1,12 @@
 use crate::checks::Check;
 use crate::common::*;
 
-pub(crate) struct EndingBlankLineChecker {
-    name: &'static str,
-    template: &'static str,
+pub(crate) struct EndingBlankLineChecker<'a> {
+    name: &'a str,
+    template: &'a str,
 }
 
-impl Default for EndingBlankLineChecker {
+impl Default for EndingBlankLineChecker<'_> {
     fn default() -> Self {
         Self {
             name: "EndingBlankLine",
@@ -15,13 +15,13 @@ impl Default for EndingBlankLineChecker {
     }
 }
 
-impl EndingBlankLineChecker {
+impl EndingBlankLineChecker<'_> {
     fn message(&self) -> String {
         format!("{}: {}", self.name, self.template)
     }
 }
 
-impl Check for EndingBlankLineChecker {
+impl Check for EndingBlankLineChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if line.raw_string.ends_with('\n') {
             None


### PR DESCRIPTION
Changes the lifetimes from 'static to 'a in EndingBlankLineChecker
Fixes #185 

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
