### PR TITLE
Updated lifetimes in LeadingCharacterChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add GitHub Workflow for AUR publishing [#161](https://github.com/dotenv-linter/dotenv-linter/pull/161) ([@mstruebing](https://github.com/mstruebing))
 
 ### 🔧 Changed
+- Replace `&'static str` with `&'a str` for ` LeadingCharacterChecker` [#200](https://github.com/dotenv-linter/dotenv-linter/pull/200) ([@rossjones](https://github.com/rossjones))
 - Replace `&'static str` with `&'a str` for `QuoteCharacterChecker` [#198](https://github.com/dotenv-linter/dotenv-linter/pull/198) ([@duncandean](https://github.com/duncandean))
 - Replace `&'static str` with `&'a str` for `EndingBlankLineChecker` [#197](https://github.com/dotenv-linter/dotenv-linter/pull/197) ([@rossjones](https://github.com/rossjones))
 - Replace `String` with `&'a str` for `UnorderedKeyChecker` [#196](https://github.com/dotenv-linter/dotenv-linter/pull/196) ([@k0va1](https://github.com/k0va1))

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -1,12 +1,12 @@
 use crate::checks::Check;
 use crate::common::*;
 
-pub(crate) struct LeadingCharacterChecker {
-    name: &'static str,
-    template: &'static str,
+pub(crate) struct LeadingCharacterChecker<'a> {
+    name: &'a str,
+    template: &'a str,
 }
 
-impl Default for LeadingCharacterChecker {
+impl Default for LeadingCharacterChecker<'_> {
     fn default() -> Self {
         Self {
             name: "LeadingCharacter",
@@ -15,13 +15,13 @@ impl Default for LeadingCharacterChecker {
     }
 }
 
-impl LeadingCharacterChecker {
+impl LeadingCharacterChecker<'_> {
     fn message(&self) -> String {
         format!("{}: {}", self.name, self.template)
     }
 }
 
-impl Check for LeadingCharacterChecker {
+impl Check for LeadingCharacterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if line.is_empty()
             || line


### PR DESCRIPTION
Changes the lifetimes from 'static to 'a in LeadingCharacterChecker.
Fixes #188

#### ✔ Checklist:
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
