### PR TITLE
Add an argument to show available checks (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add an argument to show available checks [#201](https://github.com/dotenv-linter/dotenv-linter/pull/201)  ([@DDtKey](https://github.com/DDtKey))
 - Add the ability to skip checks [#178](https://github.com/dotenv-linter/dotenv-linter/pull/178) ([@mgrachev](https://github.com/mgrachev))
 - Add check: ExtraBlankLine [#180](https://github.com/dotenv-linter/dotenv-linter/pull/180) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add check: EndingBlankLine [#170](https://github.com/dotenv-linter/dotenv-linter/pull/170) ([@evgeniy-r](https://github.com/evgeniy-r))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -33,7 +33,8 @@ fn checklist() -> Vec<Box<dyn Check>> {
 }
 
 pub fn check_names() -> Vec<String> {
-    checklist().iter()
+    checklist()
+        .iter()
         .map(|check| check.name().to_string())
         .collect()
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -32,6 +32,12 @@ fn checklist() -> Vec<Box<dyn Check>> {
     ]
 }
 
+pub fn check_names() -> Vec<String> {
+    checklist().iter()
+        .map(|check| check.name().to_string())
+        .collect()
+}
+
 pub fn run(lines: Vec<LineEntry>, skip_checks: &[&str]) -> Vec<Warning> {
     let mut checks = checklist();
     checks.retain(|c| !skip_checks.contains(&c.name()));

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -180,4 +180,12 @@ mod tests {
 
         assert_eq!(expected, run(lines, &skip_checks));
     }
+
+    #[test]
+    fn check_name_list() {
+        let expected_names = vec!["DuplicatedKey", "ExtraBlankLine", "IncorrectDelimiter",
+                                  "LeadingCharacter", "KeyWithoutValue", "LowercaseKey",
+                                  "QuoteCharacter", "SpaceCharacter", "UnorderedKey"];
+        assert_eq!(expected_names, check_names())
+    }
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -184,9 +184,17 @@ mod tests {
 
     #[test]
     fn check_name_list() {
-        let expected_names = vec!["DuplicatedKey", "ExtraBlankLine", "IncorrectDelimiter",
-                                  "LeadingCharacter", "KeyWithoutValue", "LowercaseKey",
-                                  "QuoteCharacter", "SpaceCharacter", "UnorderedKey"];
+        let expected_names = vec![
+            "DuplicatedKey",
+            "ExtraBlankLine",
+            "IncorrectDelimiter",
+            "LeadingCharacter",
+            "KeyWithoutValue",
+            "LowercaseKey",
+            "QuoteCharacter",
+            "SpaceCharacter",
+            "UnorderedKey",
+        ];
         assert_eq!(expected_names, check_names())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,11 @@ fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
                 .multiple(true)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("show-checks")
+                .long("show-checks")
+                .help("Show check list"),
+        )
         .get_matches()
 }
 
@@ -56,6 +61,13 @@ pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
     let current_dir = current_dir.as_os_str();
 
     let args = get_args(current_dir);
+
+    if args.is_present("show-checks") {
+        for name in checks::check_names() {
+            println!("{}", name);
+        }
+        return Ok(vec![]);
+    }
 
     let mut paths: Vec<PathBuf> = Vec::new();
     let mut files: Vec<FileEntry> = Vec::new();


### PR DESCRIPTION
Added functionality that displays a list of all checks if there is an argument `--show-checks` for #199
But the test I added seems redundant.
Because you will need to add the names of new checks in the future.
Perhaps it makes sense to remove it or replace with a CLI test.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [X] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
