### PR TITLE
Add an argument to show available checks (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Add an argument to show available checks [#202](https://github.com/dotenv-linter/dotenv-linter/pull/202)  ([@DDtKey](https://github.com/DDtKey))
+- Add an argument to show available checks [#202](https://github.com/dotenv-linter/dotenv-linter/pull/202) ([@DDtKey](https://github.com/DDtKey))
 - Add the ability to skip checks [#178](https://github.com/dotenv-linter/dotenv-linter/pull/178) ([@mgrachev](https://github.com/mgrachev))
 - Add check: ExtraBlankLine [#180](https://github.com/dotenv-linter/dotenv-linter/pull/180) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add check: EndingBlankLine [#170](https://github.com/dotenv-linter/dotenv-linter/pull/170) ([@evgeniy-r](https://github.com/evgeniy-r))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add an argument to show available checks [#202](https://github.com/dotenv-linter/dotenv-linter/pull/202)  ([@DDtKey](https://github.com/DDtKey))
 - Add the ability to skip checks [#178](https://github.com/dotenv-linter/dotenv-linter/pull/178) ([@mgrachev](https://github.com/mgrachev))
 - Add check: ExtraBlankLine [#180](https://github.com/dotenv-linter/dotenv-linter/pull/180) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add check: EndingBlankLine [#170](https://github.com/dotenv-linter/dotenv-linter/pull/170) ([@evgeniy-r](https://github.com/evgeniy-r))

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ $ dotenv-linter --skip UnorderedKey EndingBlankLine
 .env:2 DuplicatedKey: The FOO key is duplicated
 ```
 
+If you need to view all available checks, you can use the argument `--show-checks` (will be available in [v2.0.0](https://github.com/dotenv-linter/dotenv-linter/issues/199)):
+
+```shell script
+$ dotenv-linter --show-checks
+DuplicatedKey
+ExtraBlankLine
+IncorrectDelimiter
+LeadingCharacter
+KeyWithoutValue
+LowercaseKey
+QuoteCharacter
+SpaceCharacter
+UnorderedKey
+```
+
 ## ✅ Checks
 
 ### Duplicated Key

--- a/README.md
+++ b/README.md
@@ -182,10 +182,11 @@ If you need to view all available checks, you can use the argument `--show-check
 ```shell script
 $ dotenv-linter --show-checks
 DuplicatedKey
+EndingBlankLine
 ExtraBlankLine
 IncorrectDelimiter
-LeadingCharacter
 KeyWithoutValue
+LeadingCharacter
 LowercaseKey
 QuoteCharacter
 SpaceCharacter

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -33,10 +33,13 @@ fn checklist() -> Vec<Box<dyn Check>> {
 }
 
 pub fn available_check_names() -> Vec<String> {
-    checklist()
+    let mut names: Vec<String> = checklist()
         .iter()
         .map(|check| check.name().to_string())
-        .collect()
+        .collect();
+    names.push(ending_blank_line::EndingBlankLineChecker::default().name().to_string());
+    names.sort();
+    names
 }
 
 pub fn run(lines: Vec<LineEntry>, skip_checks: &[&str]) -> Vec<Warning> {
@@ -189,5 +192,7 @@ mod tests {
             let check_name = check.name();
             assert!(available_check_names.contains(&check_name.to_string()));
         }
+        let ending_blank_line = ending_blank_line::EndingBlankLineChecker::default();
+        assert!(available_check_names.contains(&ending_blank_line.name().to_string()));
     }
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -37,7 +37,11 @@ pub fn available_check_names() -> Vec<String> {
         .iter()
         .map(|check| check.name().to_string())
         .collect();
-    names.push(ending_blank_line::EndingBlankLineChecker::default().name().to_string());
+    names.push(
+        ending_blank_line::EndingBlankLineChecker::default()
+            .name()
+            .to_string(),
+    );
     names.sort();
     names
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -32,6 +32,13 @@ fn checklist() -> Vec<Box<dyn Check>> {
     ]
 }
 
+pub fn available_check_names() -> Vec<String> {
+    checklist()
+        .iter()
+        .map(|check| check.name().to_string())
+        .collect()
+}
+
 pub fn run(lines: Vec<LineEntry>, skip_checks: &[&str]) -> Vec<Warning> {
     let mut checks = checklist();
     checks.retain(|c| !skip_checks.contains(&c.name()));
@@ -173,5 +180,14 @@ mod tests {
         let skip_checks: Vec<&str> = vec!["KeyWithoutValue", "EndingBlankLine"];
 
         assert_eq!(expected, run(lines, &skip_checks));
+    }
+
+    #[test]
+    fn check_name_list() {
+        let available_check_names = available_check_names();
+        for check in checklist() {
+            let check_name = check.name();
+            assert!(available_check_names.contains(&check_name.to_string()));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,11 @@ fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
                 .multiple(true)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("show-checks")
+                .long("show-checks")
+                .help("Show list of available checks"),
+        )
         .get_matches()
 }
 
@@ -63,6 +68,13 @@ pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
 
     if let Some(skip) = args.values_of("skip") {
         skip_checks = skip.collect();
+    }
+
+    if args.is_present("show-checks") {
+        checks::available_check_names()
+            .iter()
+            .for_each(|name| println!("{}", name));
+        return Ok(vec![]);
     }
 
     if let Some(inputs) = args.values_of("input") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 use crate::common::*;
 
 use clap::Arg;
-use std::env;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::PathBuf;
+use std::{env, process};
 
 mod checks;
 mod common;
@@ -66,15 +66,15 @@ pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
     let mut files: Vec<FileEntry> = Vec::new();
     let mut skip_checks: Vec<&str> = Vec::new();
 
-    if let Some(skip) = args.values_of("skip") {
-        skip_checks = skip.collect();
-    }
-
     if args.is_present("show-checks") {
         checks::available_check_names()
             .iter()
             .for_each(|name| println!("{}", name));
-        return Ok(vec![]);
+        process::exit(0);
+    }
+
+    if let Some(skip) = args.values_of("skip") {
+        skip_checks = skip.collect();
     }
 
     if let Some(inputs) = args.values_of("input") {


### PR DESCRIPTION
Added functionality that displays a list of all checks if there is an argument --show-checks for #199
This argument is terminal and terminates the dotenv-linter after displaying a list of available check names.

The test was added for a new function, it may also make sense in the CLI test, but in this case, we will need to manually add names to the test in case of publication of new checks.

A usage example has been added to README.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [X] Tests for the changes have been added (for bug fixes / features);
- [X] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
