### PR TITLE
Fix for the case when many extra lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add GitHub Workflow for AUR publishing [#161](https://github.com/dotenv-linter/dotenv-linter/pull/161) ([@mstruebing](https://github.com/mstruebing))
 
 ### 🔧 Changed
+- Fix check (for several successive blank lines): ExtraBlankLine [#208](https://github.com/dotenv-linter/dotenv-linter/pull/208) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Replace `PathBuf` with `FileEntry` for `LineEntry` [#203](https://github.com/dotenv-linter/dotenv-linter/pull/203) ([@mgrachev](https://github.com/mgrachev))
 - Replace `&'static str` with `&'a str` for ` LeadingCharacterChecker` [#200](https://github.com/dotenv-linter/dotenv-linter/pull/200) ([@rossjones](https://github.com/rossjones))
 - Replace `&'static str` with `&'a str` for `QuoteCharacterChecker` [#198](https://github.com/dotenv-linter/dotenv-linter/pull/198) ([@duncandean](https://github.com/duncandean))

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -29,12 +29,14 @@ impl Check for ExtraBlankLineChecker<'_> {
             return None;
         }
 
-        if let Some(last_blank_number) = self.last_blank_number {
-            if last_blank_number + 1 == line.number {
-                return Some(Warning::new(line.clone(), self.message()));
-            }
-        }
+        let is_extra = self
+            .last_blank_number
+            .map_or(false, |n| n + 1 == line.number);
         self.last_blank_number = Some(line.number);
+
+        if is_extra {
+            return Some(Warning::new(line.clone(), self.message()));
+        }
 
         None
     }
@@ -87,6 +89,19 @@ mod tests {
         let asserts = vec![
             ("A=B", None),
             ("", None),
+            ("", Some("ExtraBlankLine: Extra blank line detected")),
+            ("C=D", None),
+        ];
+
+        run_asserts(asserts);
+    }
+
+    #[test]
+    fn three_blank_lines() {
+        let asserts = vec![
+            ("A=B", None),
+            ("", None),
+            ("", Some("ExtraBlankLine: Extra blank line detected")),
             ("", Some("ExtraBlankLine: Extra blank line detected")),
             ("C=D", None),
         ];


### PR DESCRIPTION
I found the small bug in the `ExtraBlankLine` check: it prints less warnings than expected when there are several successive blank lines.
For example, it prints only one warning for this file (instead of two):
```env
A=B



B=C

```


#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
