### PR TITLE
Provide more short way to install dotenv-linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,17 @@ jobs:
           args: --package dotenv-linter
         if: steps.cache-target.outputs.cache-hit != 'true'
 
+  install:
+    name: Install / Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup dotenv-linter
+        run: |
+          mkdir -p $HOME/bin
+          curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b $HOME/bin
+      - name: Verify successful installation
+        run: $HOME/bin/dotenv-linter -v
+
   windows_build:
     name: Build / Windows
     runs-on: windows-latest
@@ -260,3 +271,14 @@ jobs:
           command: clean
           args: --package dotenv-linter
         if: steps.cache-target.outputs.cache-hit != 'true'
+
+  macos_install:
+    name: Install / MacOS
+    runs-on: macos-latest
+    steps:
+      - name: Setup dotenv-linter
+        run: |
+          mkdir -p $HOME/bin
+          curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b $HOME/bin
+      - name: Verify successful installation
+        run: $HOME/bin/dotenv-linter -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           args: --package dotenv-linter
         if: steps.cache-target.outputs.cache-hit != 'true'
 
-  install:
+  linux_install:
     name: Install / Linux
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,11 @@ jobs:
     name: Install / Linux
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
       - name: Setup dotenv-linter
         run: |
           mkdir -p $HOME/bin
-          curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b $HOME/bin
+          sh "${GITHUB_WORKSPACE}/install.sh" -b $HOME/bin
       - name: Verify successful installation
         run: $HOME/bin/dotenv-linter -v
 
@@ -276,9 +277,10 @@ jobs:
     name: Install / MacOS
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v1
       - name: Setup dotenv-linter
         run: |
           mkdir -p $HOME/bin
-          curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b $HOME/bin
+          sh "${GITHUB_WORKSPACE}/install.sh" -b $HOME/bin
       - name: Verify successful installation
         run: $HOME/bin/dotenv-linter -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add install.sh for provide more short way to install [#220](https://github.com/dotenv-linter/dotenv-linter/pull/220) ([@DDtKey](https://github.com/DDtKey))
 - Add Windows publishing to release workflow [#211](https://github.com/dotenv-linter/dotenv-linter/pull/211) ([@DDtKey](https://github.com/DDtKey))
 - Add support canonicalize path for Windows [#213](https://github.com/dotenv-linter/dotenv-linter/pull/213) ([@DDtKey](https://github.com/DDtKey))
 - Add build and test steps running on Windows [#216](https://github.com/dotenv-linter/dotenv-linter/pull/216) ([@mgrachev](https://github.com/mgrachev))

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Articles about dotenv-linter:
 
 ```shell script
 # Linux / macOS / Windows (MINGW and etc)
-$ curl -sfl https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
+$ curl -sfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
 # Alpine Linux (wget)
-$ wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
+$ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
 # Specific version
-$ curl -sfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s "v1.2.0"
+$ curl -sfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s "v1.2.0"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Articles about dotenv-linter:
 # Linux / macOS / Windows (MINGW and etc)
 $ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
+# Specify installation directory and version.
+$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b usr/local/bin v2.0.0
+
 # Alpine Linux (wget)
 $ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
-
-# Specific version
-$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s v1.2.0
 ```
 
 ### Homebrew / Linuxbrew

--- a/README.md
+++ b/README.md
@@ -58,14 +58,15 @@ Articles about dotenv-linter:
 ### Binary
 
 ```shell script
-# Linux
-$ curl https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-linux-x86_64.tar.gz -sSfL | tar -xzf -
+# Linux / macOS / Windows (MINGW and etc)
+$ curl -sfl https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
 
-# Alpine Linux
-$ wget https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-alpine-x86_64.tar.gz -O - -q | tar -xzf -
+# Alpine Linux (wget)
+$ wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
 
-# macOS
-$ curl https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-darwin-x86_64.tar.gz -sSfL | tar -xzf -
+# Specific version
+$ curl -sfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s "v1.2.0"
+
 ```
 
 ### Homebrew / Linuxbrew

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Articles about dotenv-linter:
 ### Binary
 
 ```shell script
-# Linux / macOS / Windows (MINGW and etc)
-$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
+# Linux / macOS / Windows (MINGW and etc). Installs it into ./bin/ by default.
+$ curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
 
 # Specify installation directory and version.
-$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b usr/local/bin v2.0.0
+$ curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s -- -b usr/local/bin v2.0.0
 
 # Alpine Linux (wget)
-$ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
+$ wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
 ```
 
 ### Homebrew / Linuxbrew

--- a/README.md
+++ b/README.md
@@ -59,14 +59,13 @@ Articles about dotenv-linter:
 
 ```shell script
 # Linux / macOS / Windows (MINGW and etc)
-$ curl -sfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
+$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
 # Alpine Linux (wget)
 $ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
 # Specific version
-$ curl -sfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s "v1.2.0"
-
+$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s v1.2.0
 ```
 
 ### Homebrew / Linuxbrew

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,14 +5,14 @@ You can install the pre-compiled binary (in several different ways), use Docker 
 **Binary**
 
 ```shell script
-# Linux / macOS / Windows (MINGW and etc)
-$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
+# Linux / macOS / Windows (MINGW and etc). Installs it into ./bin/ by default.
+$ curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
 
 # Specify installation directory and version.
-$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b usr/local/bin v2.0.0
+$ curl -sSfL https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s -- -b usr/local/bin v2.0.0
 
 # Alpine Linux (wget)
-$ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
+$ wget -q -O - https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh | sh -s
 ```
 
 **Homebrew / Linuxbrew**

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,14 +5,14 @@ You can install the pre-compiled binary (in several different ways), use Docker 
 **Binary**
 
 ```shell script
-# Linux
-$ curl https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-linux-x86_64.tar.gz -sSfL | tar -xzf -
+# Linux / macOS / Windows (MINGW and etc)
+$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
-# Alpine Linux
-$ wget https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-alpine-x86_64.tar.gz -O - -q | tar -xzf -
+# Alpine Linux (wget)
+$ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
-# macOS
-$ curl https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-darwin-x86_64.tar.gz -sSfL | tar -xzf -
+# Specific version
+$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s v1.2.0
 ```
 
 **Homebrew / Linuxbrew**

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,11 +8,11 @@ You can install the pre-compiled binary (in several different ways), use Docker 
 # Linux / macOS / Windows (MINGW and etc)
 $ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
 
+# Specify installation directory and version.
+$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s -- -b usr/local/bin v2.0.0
+
 # Alpine Linux (wget)
 $ wget -q -O - "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s
-
-# Specific version
-$ curl -sSfL "https://raw.githubusercontent.com/dotenv-linter/dotenv-linter/master/install.sh" | sh -s v1.2.0
 ```
 
 **Homebrew / Linuxbrew**

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,6 @@ DOTENV_LINTER="dotenv-linter"
 DOTENV_LINTER_REPO="${DOTENV_LINTER}/${DOTENV_LINTER}"
 DOTENV_LINTER_GITHUB="https://github.com/${DOTENV_LINTER_REPO}"
 DOTENV_LINTER_RELEASES="${DOTENV_LINTER_GITHUB}/releases"
-DOTENV_LINTER_RELEASE_API="https://api.github.com/repos/${DOTENV_LINTER_REPO}/releases/latest"
 
 usage() {
     require_cmd cat
@@ -68,14 +67,12 @@ main() {
     _archive_name="${DOTENV_LINTER}-${_arch}${_ext}"
 
     if [ -z "${TAG}" ]; then
-        get_latest_version || return 1
-        _target_version="$RETVAL"
+        println "The latest version will be installed."
+        _url="${DOTENV_LINTER_RELEASES}/latest/download/${_archive_name}"
     else
-        _target_version="${TAG}"
+        println "Version ${TAG} will be installed"
+        _url="${DOTENV_LINTER_RELEASES}/download/${TAG}/${_archive_name}"
     fi
-
-    println "Version ${_target_version} will be installed"
-    _url="${DOTENV_LINTER_RELEASES}/download/${_target_version}/${_archive_name}"
 
     # Installation
     _temp_dir=$(mktemp -d)
@@ -103,17 +100,6 @@ main() {
     rm -rf "${_temp_dir}"
 
     return 0;
-}
-
-get_latest_version() {
-    require_cmd cut
-
-    download "${DOTENV_LINTER_RELEASE_API}" || return 1
-    _latest_version=$(
-         echo "$RETVAL" | grep '"tag_name":' | cut -d'"' -f4
-    )
-
-    RETVAL=${_latest_version}
 }
 
 get_architecture() {
@@ -163,24 +149,14 @@ get_architecture() {
 # $1 - url for download. $2 - path to download
 # Wrapper function for curl/wget
 download() {
-    if [ $# -eq 0 ]; then
-        err "URL not specified"
+    if [ ! $# -eq 2 ]; then
+        err "URL or target path not specified"
     fi
 
     if cmd_exists curl; then
-        if [ $# -eq 2 ]; then
-            curl -sSfL "$1" -o "$2"
-        else
-            RETVAL=$(curl -sSfL "$1")
-        fi
-
+        curl -sSfL "$1" -o "$2"
     elif cmd_exists wget; then
-        if [ $# -eq 2 ] ; then
-            wget -q "$1" -O "$2"
-        else
-            RETVAL=$(wget -q -O - "$1")
-        fi
-
+        wget -q "$1" -O "$2"
     else
         err "Not found download command. 'curl' or 'wget' is required."
     fi

--- a/install.sh
+++ b/install.sh
@@ -1,121 +1,108 @@
-#!/bin/bash
+#!/bin/sh
 
-set -u
+set -e
 
 DOTENV_LINTER="dotenv-linter"
 DOTENV_LINTER_REPO="${DOTENV_LINTER}/${DOTENV_LINTER}"
 DOTENV_LINTER_GITHUB="https://github.com/${DOTENV_LINTER_REPO}"
-DOTENV_LINTER_RELEASE_API="https://api.github.com/repos/${DOTENV_LINTER_REPO}/releases/latest"
+DOTENV_LINTER_RELEASES="${DOTENV_LINTER_GITHUB}/releases"
+
+usage() {
+    this=$1
+    cat 1>&2 <<EOF
+$this: download binaries for dotenv-linter
+
+USAGE:
+    $this [FLAGS] [OPTIONS] <tag>
+
+FLAGS:
+    -h, --help      Prints help information
+
+OPTIONS:
+    -b, --bindir <DIR_PATH>     Sets bindir or installation directory, Defaults to ./bin
+
+ARGS:
+    <tag>       is a tag from ${DOTENV_LINTER_RELEASES}. If tag is missing, then the latest will be used.
+EOF
+    exit 2
+}
+
+parse_args() {
+  BINDIR=${BINDIR:-./bin}
+  while [ "$#" -gt 0 ]; do
+    case $1 in
+        -h|--help)
+            usage "$0"
+            shift #past argument
+            ;;
+        -b|--bindir)
+            BINDIR="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        *) TAG=$1
+            shift # past argument
+            ;;
+    esac
+  done
+}
 
 main() {
+    parse_args "$@"
+
     require_cmd uname
-    require_cmd mkdir
+    require_cmd mktemp
     require_cmd grep
-    require_cmd cut
+    require_cmd cat
     require_cmd rm
 
-    local _target_version
-    if [ $# -eq 0 ]; then
-        get_latest_version || return 1
-        _target_version="$RETVAL"
-    else
-        _target_version="$1"
-    fi
-
     get_architecture || return 1
-    local _arch="$RETVAL"
+    _arch="$RETVAL"
 
-    local _ext
     case $_arch in
         win-*) _ext=".zip" ;;
         *) _ext=".tar.gz" ;;
     esac
 
-    local _archive_name="${DOTENV_LINTER}-${_arch}${_ext}"
-    local _url="${DOTENV_LINTER_GITHUB}/releases/download/${_target_version}/${_archive_name}"
+    _archive_name="${DOTENV_LINTER}-${_arch}${_ext}"
 
-    # Installation
-    local _dir="$HOME/.${DOTENV_LINTER}"
-    local _version_dir="${_dir}/${_target_version}"
-
-    if [ ! -e "$_version_dir/${DOTENV_LINTER}" ]; then
-        mkdir -p "$_version_dir"
-
-        local _archive_path="${_version_dir}/${_archive_name}"
-        download "${_url}" "${_archive_path}" || return 1
-
-        case $_archive_path in
-            *.zip)
-                required_cmd unzip
-                unzip "${_archive_path}" -d "${_version_dir}"
-            ;;
-            *)  require_cmd tar
-                tar -xzf "${_archive_path}" -C "${_version_dir}"
-            ;;
-        esac
-
-        rm "${_archive_path}"
-
-        println "Successful download \"dotenv-linter\" to ${_version_dir}"!
+    if [ -z "${TAG}" ]; then
+        println "The latest version will be installed."
+        _url="${DOTENV_LINTER_RELEASES}/latest/download/${_archive_name}"
     else
-        println "WARN:: ${_version_dir} already exists! We just switch the version to ${_target_version}"
-        println "Or you can manually remove dir: 'rm -rf ${_version_dir}' and reinstall."
+        println "Version ${TAG} will be installed"
+        _url="${DOTENV_LINTER_RELEASES}/download/${TAG}/${_archive_name}"
     fi
 
-    # Setup installed version as executable
-    setup_executable "${_dir}" "${_target_version}" || return 1
+    # Installation
+    _temp_dir=$(mktemp -d)
+    _archive_path="${_temp_dir}/${_archive_name}"
+
+    download "${_url}" "${_archive_path}" || return 1
+
+    case $_archive_path in
+        *.zip)
+            required_cmd unzip
+            unzip "${_archive_path}" -d "${_temp_dir}"
+            _file_name="${DOTENV_LINTER}.exe"
+        ;;
+        *)  require_cmd tar
+            tar -xzf "${_archive_path}" -C "${_temp_dir}"
+            _file_name="${DOTENV_LINTER}"
+        ;;
+    esac
+
+    test ! -d "${BINDIR}" && install -d "${BINDIR}"
+
+    install "${_temp_dir}/${_file_name}" "${BINDIR}/"
+    println "Successfully installed to ${BINDIR}/${_file_name}"
+
+    rm -rf "${_temp_dir}"
 
     return 0;
 }
 
-# $1 - dotenv-linter dir, $2 - target version
-setup_executable() {
-    local _bin_dir="$1/bin"
-    if [ ! -d "$_bin_dir" ]; then
-	    mkdir -p "$_bin_dir"
-    fi
-
-    local _bin_file="${_bin_dir}/${DOTENV_LINTER}"
-    ln -sf "$1/$2/${DOTENV_LINTER}" "${_bin_file}"
-
-    local _shell_profile
-    case ${SHELL-undefined} in
-        /bin/zsh) _shell_profile=~/".zshrc" ;;
-        *) _shell_profile=~/".bashrc" ;;
-	esac
-
-    if [ -e "$_shell_profile" ]; then
-        case :$PATH: in
-            *:$_bin_dir:*) ;; # do nothing, already exists
-            *)  echo "export PATH=\"$_bin_dir:\$PATH\"" >> "${_shell_profile}"
-                export PATH="${_bin_dir}:$PATH"
-                println "Will be available in new terminal sessions or after update config: \". ${_shell_profile}\""
-            ;;
-        esac
-    fi
-
-    if ! cmd_exists dotenv-linter ; then
-        println ""
-	    println "Manually add the directory to your environment:"
-        println "   export PATH=\"\$PATH:${_bin_dir}\""
-        println ""
-	fi
-
-	println "Run '${DOTENV_LINTER} --help' to get started"
-}
-
-get_latest_version() {
-    local _latest_version
-    download "${DOTENV_LINTER_RELEASE_API}" || return 1
-    _latest_version=$(
-         echo "$RETVAL" | grep '"tag_name":' | cut -d'"' -f4
-    )
-
-    RETVAL=${_latest_version}
-}
-
 get_architecture() {
-    local _ostype _cputype _clibtype
     _ostype="$(uname -s)"
     _cputype="$(uname -m)"
     _clibtype="gnu"
@@ -124,7 +111,7 @@ get_architecture() {
 	    err "Error: Unsupported architecture $_cputype. Only x86_64 binaries are available."
     fi
 
-    if [ "$_ostype" = Linux ]; then
+    if [ "$_ostype" = "Linux" ]; then
         if ldd --version 2>&1 | grep -q 'musl'; then
             _clibtype="musl"
         fi
@@ -162,24 +149,14 @@ get_architecture() {
 # $1 - url for download. $2 - path to download
 # Wrapper function for curl/wget
 download() {
-    if [ $# -eq 0 ]; then
-        err "URL not specified"
+    if [ ! $# -eq 2 ]; then
+        err "URL or target path not specified"
     fi
 
     if cmd_exists curl; then
-        if [ $# -eq 2 ]; then
-            curl -sSfL "$1" -o "$2"
-        else
-            RETVAL=$(curl -sSfL "$1")
-        fi
-
+        curl -sSfL "$1" -o "$2"
     elif cmd_exists wget; then
-        if [ $# -eq 2 ] ; then
-            wget -q "$1" -O "$2"
-        else
-            RETVAL=$(wget -q -O - "$1")
-        fi
-
+        wget -q "$1" -O "$2"
     else
         err "Not found download command. 'curl' or 'wget' is required."
     fi
@@ -205,7 +182,7 @@ err() {
 }
 
 println() {
-    printf '%s installer:   %s\n' "${DOTENV_LINTER}" "$1"
+    printf '%s installer: %s\n' "${DOTENV_LINTER}" "$1"
 }
 
 main "$@" || exit 1

--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,7 @@ setup_executable() {
         case :$PATH: in
             *:$_bin_dir:*) ;; # do nothing, already exists
             *)  echo "export PATH=\"$_bin_dir:\$PATH\"" >> "${_shell_profile}"
-                # shellcheck source=$shell_profile
-                . "${_shell_profile}" # upd config
+                export PATH="${_bin_dir}:$PATH"
                 println "Will be available in new terminal sessions or after update config: \". ${_shell_profile}\""
             ;;
         esac
@@ -97,7 +96,7 @@ setup_executable() {
 
     if ! cmd_exists dotenv-linter ; then
         println ""
-	    println "Manually add the directory to your environment"
+	    println "Manually add the directory to your environment:"
         println "   export PATH=\"\$PATH:${_bin_dir}\""
         println ""
 	fi

--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,9 @@ main() {
     test ! -d "${BINDIR}" && install -d "${BINDIR}"
 
     install "${_temp_dir}/${_file_name}" "${BINDIR}/"
-    println "Successfully installed to ${BINDIR}/${_file_name}"
+    _exe_path=${BINDIR}/${_file_name}
+
+    println "Successfully installed $($_exe_path -v) to ${_exe_path}"
 
     rm -rf "${_temp_dir}"
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+set -u
+
+DOTENV_LINTER="dotenv-linter"
+DOTENV_LINTER_REPO="${DOTENV_LINTER}/${DOTENV_LINTER}"
+DOTENV_LINTER_GITHUB="https://github.com/${DOTENV_LINTER_REPO}"
+DOTENV_LINTER_RELEASE_API="https://api.github.com/repos/${DOTENV_LINTER_REPO}/releases/latest"
+
+main() {
+    require_cmd uname
+    require_cmd mkdir
+    require_cmd grep
+    require_cmd cut
+    require_cmd rm
+
+    local _target_version
+    if [ $# -eq 0 ]; then
+        get_latest_version || return 1
+        _target_version="$RETVAL"
+    else
+        _target_version="$1"
+    fi
+
+    get_architecture || return 1
+    local _arch="$RETVAL"
+
+    local _ext
+    case $_arch in
+        win-*) _ext=".zip" ;;
+        *) _ext=".tar.gz" ;;
+    esac
+
+    local _archive_name="${DOTENV_LINTER}-${_arch}${_ext}"
+    local _url="${DOTENV_LINTER_GITHUB}/releases/download/${_target_version}/${_archive_name}"
+
+    # Installation
+    local _dir="$HOME/.${DOTENV_LINTER}"
+    local _version_dir="${_dir}/${_target_version}"
+
+    if [ ! -e "$_version_dir/${DOTENV_LINTER}" ]; then
+        mkdir -p "$_version_dir"
+
+        local _archive_path="${_version_dir}/${_archive_name}"
+        download "${_url}" "${_archive_path}" || return 1
+
+        case $_archive_path in
+            *.zip)
+                required_cmd unzip
+                unzip "${_archive_path}" -d "${_version_dir}"
+            ;;
+            *)  require_cmd tar
+                tar -xzf "${_archive_path}" -C "${_version_dir}"
+            ;;
+        esac
+
+        rm "${_archive_path}"
+
+        println "Successful download \"dotenv-linter\" to ${_version_dir}"!
+    else
+        println "WARN:: ${_version_dir} already exists! We just switch the version to ${_target_version}"
+        println "Or you can manually remove dir: 'rm -rf ${_version_dir}' and reinstall."
+    fi
+
+    # Setup installed version as executable
+    setup_executable "${_dir}" "${_target_version}" || return 1
+
+    return 0;
+}
+
+# $1 - dotenv-linter dir, $2 - target version
+setup_executable() {
+    local _bin_dir="$1/bin"
+    if [ ! -d "$_bin_dir" ]; then
+	    mkdir -p "$_bin_dir"
+    fi
+
+    local _bin_file="${_bin_dir}/${DOTENV_LINTER}"
+    ln -sf "$1/$2/${DOTENV_LINTER}" "${_bin_file}"
+
+    local _shell_profile
+    case ${SHELL-undefined} in
+        /bin/zsh) _shell_profile=~/".zshrc" ;;
+        *) _shell_profile=~/".bashrc" ;;
+	esac
+
+    if [ -e "$_shell_profile" ]; then
+        case :$PATH: in
+            *:$_bin_dir:*) ;; # do nothing, already exists
+            *)  echo "export PATH=\"$_bin_dir:\$PATH\"" >> "${_shell_profile}"
+                # shellcheck source=$shell_profile
+                . "${_shell_profile}" # upd config
+                println "Will be available in new terminal sessions or after update config: \". ${_shell_profile}\""
+            ;;
+        esac
+    fi
+
+    if ! cmd_exists dotenv-linter ; then
+        println ""
+	    println "Manually add the directory to your environment"
+        println "   export PATH=\"\$PATH:${_bin_dir}\""
+        println ""
+	fi
+
+	println "Run '${DOTENV_LINTER} --help' to get started"
+}
+
+get_latest_version() {
+    local _latest_version
+    download "${DOTENV_LINTER_RELEASE_API}" || return 1
+    _latest_version=$(
+         echo "$RETVAL" | grep '"tag_name":' | cut -d'"' -f4
+    )
+
+    RETVAL=${_latest_version}
+}
+
+get_architecture() {
+    local _ostype _cputype _clibtype
+    _ostype="$(uname -s)"
+    _cputype="$(uname -m)"
+    _clibtype="gnu"
+
+    if [ "$_cputype" != "x86_64" ]; then
+	    err "Error: Unsupported architecture $_cputype. Only x86_64 binaries are available."
+    fi
+
+    if [ "$_ostype" = Linux ]; then
+        if ldd --version 2>&1 | grep -q 'musl'; then
+            _clibtype="musl"
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Linux)
+            if [ "$_clibtype" != "musl" ]; then
+                _ostype=linux
+            else
+                # For 'musl' architecture we release alpine version
+                _ostype=alpine
+            fi
+        ;;
+
+        Darwin)
+            _ostype=darwin
+        ;;
+
+        CYGWIN*|MINGW32*|MSYS*|MINGW*) # windows systems
+            _ostype=win
+            _cputype="x64"
+        ;;
+
+        *)
+            err "Unsupported OS type: $_ostype"
+        ;;
+
+    esac
+
+    RETVAL="${_ostype}-${_cputype}"
+}
+
+# $1 - url for download. $2 - path to download
+# Wrapper function for curl/wget
+download() {
+    if [ $# -eq 0 ]; then
+        err "URL not specified"
+    fi
+
+    if cmd_exists curl; then
+        if [ $# -eq 2 ]; then
+            curl -sSfL "$1" -o "$2"
+        else
+            RETVAL=$(curl -sSfL "$1")
+        fi
+
+    elif cmd_exists wget; then
+        if [ $# -eq 2 ] ; then
+            wget -q "$1" -O "$2"
+        else
+            RETVAL=$(wget -q -O - "$1")
+        fi
+
+    else
+        err "Not found download command. 'curl' or 'wget' is required."
+    fi
+
+    if [ $# -eq 2 ] && [ ! -f "$2" ]; then
+        err "Failed to download file $1"
+    fi
+}
+
+require_cmd() {
+    if ! cmd_exists "$1"; then
+        err "'$1' is required (command not found)."
+    fi
+}
+
+cmd_exists() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+err() {
+    println "$1" >&2
+    exit 1
+}
+
+println() {
+    printf '%s installer:   %s\n' "${DOTENV_LINTER}" "$1"
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
Implemented a script for more short way to install dotenv-linter (#112).

The advantage of the solution is its cross-platform.
The script is executed with `curl`/`wget` and even _under Windows_ (checked on `MINGW`).

Complexity is the process of automatically declaring an environment variable. In some cases, this is only possible manually at the moment.

This is a working version, I also tested on Alpine Linux.

**But I would like to hear any ideas for improving or changing the approach.**

Perhaps when we come to a final decision, it makes sense to create a separate repository.
Although for installing binaries with a script, it looks suitable in this repo, so far it is not more than 1 file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [X] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
