### PR TITLE
Consider blank lines in UnorderedKey check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add build and test steps running on Windows [#216](https://github.com/dotenv-linter/dotenv-linter/pull/216) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Consider blank lines in `UnorderedKey` check [#221](https://github.com/dotenv-linter/dotenv-linter/pull/221) ([@mgrachev](https://github.com/mgrachev))
 - Optimize integration tests [#218](https://github.com/dotenv-linter/dotenv-linter/pull/218) ([@mgrachev](https://github.com/mgrachev))
 
 ## [v2.0.0] - 2020-06-15

--- a/README.md
+++ b/README.md
@@ -382,6 +382,19 @@ BAR=FOO
 FOO=BAR
 ```
 
+You can use blank lines to split lines into groups:
+
+```env
+❌ Wrong
+FOO=BAR
+BAR=FOO
+
+✅ Correct 
+FOO=BAR
+
+BAR=FOO
+```
+
 ## 🤝 Contributing
 
 If you've ever wanted to contribute to open source, now you have a great opportunity:

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -31,6 +31,11 @@ impl Default for UnorderedKeyChecker<'_> {
 
 impl Check for UnorderedKeyChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+        if line.is_empty() {
+            self.keys.clear();
+            return None;
+        }
+
         let key = line.get_key()?;
         self.keys.push(key.clone());
         let mut sorted_keys = self.keys.clone();
@@ -362,6 +367,50 @@ mod tests {
                         total_lines: 4,
                     },
                     raw_string: String::from("ZOO=BAR"),
+                },
+                None,
+            ),
+        ];
+
+        run_unordered_tests(asserts);
+    }
+
+    #[test]
+    fn one_unordered_key_with_blank_line_test() {
+        let asserts = vec![
+            (
+                LineEntry {
+                    number: 1,
+                    file: FileEntry {
+                        path: PathBuf::from(".env"),
+                        file_name: ".env".to_string(),
+                        total_lines: 3,
+                    },
+                    raw_string: String::from("FOO=BAR"),
+                },
+                None,
+            ),
+            (
+                LineEntry {
+                    number: 2,
+                    file: FileEntry {
+                        path: PathBuf::from(".env"),
+                        file_name: ".env".to_string(),
+                        total_lines: 3,
+                    },
+                    raw_string: String::from(""),
+                },
+                None,
+            ),
+            (
+                LineEntry {
+                    number: 3,
+                    file: FileEntry {
+                        path: PathBuf::from(".env"),
+                        file_name: ".env".to_string(),
+                        total_lines: 3,
+                    },
+                    raw_string: String::from("BAR=FOO"),
                 },
                 None,
             ),

--- a/src/common.rs
+++ b/src/common.rs
@@ -218,11 +218,13 @@ mod tests {
                 (".env", true),
                 ("foo.env", true),
                 (".env.foo", true),
+                (".env.foo.common", true),
                 ("env", false),
                 ("env.foo", false),
                 ("foo_env", false),
                 ("foo-env", false),
                 (".my-env-file", false),
+                ("dev.env.js", false),
             ];
 
             for (file_name, expected) in assertions {


### PR DESCRIPTION
In some projects, I work with large `.env` files which have more than 200 lines.
Sorting these files is a really big problem.
The solution is to use groups of lines separated by blank lines. For example:
```env
❌ Wrong
FOO=BAR
BAR=FOO

✅ Correct
BAR=FOO
FOO=BAR

✅ Correct
FOO=BAR

BAR=FOO
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
