### PR TITLE
Move show-checks flag to main.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add build and test steps running on Windows [#216](https://github.com/dotenv-linter/dotenv-linter/pull/216) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Move show-checks flag to main.rs [#227](https://github.com/dotenv-linter/dotenv-linter/pull/227) ([@mgrachev](https://github.com/mgrachev))
 - Fix `total_lines` in some tests [#224](https://github.com/dotenv-linter/dotenv-linter/pull/224) ([@DDtKey](https://github.com/DDtKey))
 - Consider blank lines in `UnorderedKey` check [#221](https://github.com/dotenv-linter/dotenv-linter/pull/221) ([@mgrachev](https://github.com/mgrachev))
 - Optimize integration tests [#218](https://github.com/dotenv-linter/dotenv-linter/pull/218) ([@mgrachev](https://github.com/mgrachev))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -39,12 +39,10 @@ fn checklist() -> Vec<Box<dyn Check>> {
 }
 
 pub fn available_check_names() -> Vec<String> {
-    let mut names: Vec<String> = checklist()
+    checklist()
         .iter()
         .map(|check| check.name().to_string())
-        .collect();
-    names.sort();
-    names
+        .collect()
 }
 
 pub fn run(lines: Vec<LineEntry>, skip_checks: &[&str]) -> Vec<Warning> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,74 +1,19 @@
 use crate::common::*;
 
-use clap::Arg;
 use std::error::Error;
-use std::ffi::OsStr;
 use std::path::PathBuf;
-use std::{env, process};
 
 mod checks;
 mod common;
 mod fs_utils;
 
-fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
-    clap::App::new(env!("CARGO_PKG_NAME"))
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .version_short("v")
-        .arg(
-            Arg::with_name("input")
-                .help("files or paths")
-                .index(1)
-                .default_value_os(current_dir)
-                .required(true)
-                .multiple(true),
-        )
-        .arg(
-            Arg::with_name("exclude")
-                .short("e")
-                .long("exclude")
-                .value_name("FILE_NAME")
-                .help("Excludes files from check")
-                .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("skip")
-                .short("s")
-                .long("skip")
-                .value_name("CHECK_NAME")
-                .help("Skips checks")
-                .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("show-checks")
-                .long("show-checks")
-                .help("Shows list of available checks"),
-        )
-        .get_matches()
-}
+pub use checks::available_check_names;
 
 #[allow(clippy::redundant_closure)]
-pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
-    let current_dir = match env::current_dir() {
-        Ok(dir) => dir,
-        Err(e) => return Err(Box::new(e)),
-    };
-
-    let args = get_args(current_dir.as_os_str());
-
+pub fn run(args: clap::ArgMatches, current_dir: &PathBuf) -> Result<Vec<Warning>, Box<dyn Error>> {
     let mut dirs: Vec<PathBuf> = Vec::new();
     let mut file_paths: Vec<PathBuf> = Vec::new();
     let mut skip_checks: Vec<&str> = Vec::new();
-
-    if args.is_present("show-checks") {
-        checks::available_check_names()
-            .iter()
-            .for_each(|name| println!("{}", name));
-        process::exit(0);
-    }
 
     if let Some(skip) = args.values_of("skip") {
         skip_checks = skip.collect();
@@ -121,7 +66,7 @@ pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
 
         let file_with_lines = match FileEntry::from(relative_path) {
             Some(f) => f,
-            _ => continue,
+            None => continue,
         };
 
         let lines = get_line_entries(file_with_lines.0, file_with_lines.1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,64 @@
-extern crate clap;
-extern crate dotenv_linter;
+use clap::Arg;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::{env, process};
 
-use std::process;
+fn main() -> Result<(), Box<dyn Error>> {
+    let current_dir = env::current_dir()?;
+    let args = get_args(current_dir.as_os_str());
 
-fn main() {
-    match dotenv_linter::run() {
-        Ok(warnings) => {
-            if warnings.is_empty() {
-                process::exit(0);
-            }
+    if args.is_present("show-checks") {
+        dotenv_linter::available_check_names()
+            .iter()
+            .for_each(|name| println!("{}", name));
+        process::exit(0);
+    }
 
-            warnings.iter().for_each(|w| println!("{}", w));
-        }
-        Err(error) => {
-            eprintln!("dotenv-linter: {}", error);
-        }
-    };
+    let warnings = dotenv_linter::run(args, &current_dir)?;
+    if warnings.is_empty() {
+        process::exit(0);
+    }
 
+    warnings.iter().for_each(|w| println!("{}", w));
     process::exit(1);
+}
+
+fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
+    clap::App::new(env!("CARGO_PKG_NAME"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .version_short("v")
+        .arg(
+            Arg::with_name("input")
+                .help("files or paths")
+                .index(1)
+                .default_value_os(current_dir)
+                .required(true)
+                .multiple(true),
+        )
+        .arg(
+            Arg::with_name("exclude")
+                .short("e")
+                .long("exclude")
+                .value_name("FILE_NAME")
+                .help("Excludes files from check")
+                .multiple(true)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("skip")
+                .short("s")
+                .long("skip")
+                .value_name("CHECK_NAME")
+                .help("Skips checks")
+                .multiple(true)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("show-checks")
+                .long("show-checks")
+                .help("Shows list of available checks"),
+        )
+        .get_matches()
 }


### PR DESCRIPTION
What have been done:
- [x] Sorting is removed from the `available_check_names` method, because all checks are already in alphabetical order;
- [x] The `show checks` flag is moved to `main.rs` file, because it allowed to exit from the program.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
