### PR TITLE
Autofix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add autofix feature (just one check for now - LowercaseKey) [#228](https://github.com/dotenv-linter/dotenv-linter/pull/228) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Add autofix feature (just one check for now - LowercaseKey) [#228](https://github.com/dotenv-linter/dotenv-linter/pull/228) ([@evgeniy-r](https://github.com/evgeniy-r))
+- Add autofix feature (for LowercaseKey check) [#228](https://github.com/dotenv-linter/dotenv-linter/pull/228) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ TrailingWhitespace
 UnorderedKey
 ```
 
+`dotenv-linter` can also automatically fix warnings in the files. Currently only one kind of warnings is fixed
+(`LowercaseKey`). You should use the argument `--fix` (or its short version `-f`) for this.
+
+```shell script
+$ dotenv-linter -f
+Fixed warnings:
+.env:3 LowercaseKey: The foo key should be in uppercase
+
+Unfixed warnings:
+.env:2 DuplicatedKey: The BAR key is duplicated
+```
+
 ## ✅ Checks
 
 ### Duplicated Key

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ UnorderedKey
 ```
 
 `dotenv-linter` can also automatically fix warnings in the files. Currently only one kind of warnings is fixed
-(`LowercaseKey`). You should use the argument `--fix` (or its short version `-f`) for this.
+(`LowercaseKey`). You should use the argument `--fix` (or its short version `-f`) for this (will be available in [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/issues/238):
 
 ```shell script
 $ dotenv-linter -f

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -45,13 +45,13 @@ pub fn available_check_names() -> Vec<String> {
         .collect()
 }
 
-pub fn run(lines: Vec<LineEntry>, skip_checks: &[&str]) -> Vec<Warning> {
+pub fn run(lines: &[LineEntry], skip_checks: &[&str]) -> Vec<Warning> {
     let mut checks = checklist();
     checks.retain(|c| !skip_checks.contains(&c.name()));
 
     let mut warnings: Vec<Warning> = Vec::new();
 
-    for line in &lines {
+    for line in lines {
         let is_comment = line.is_comment();
         for ch in &mut checks {
             if is_comment && ch.skip_comments() {
@@ -101,7 +101,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(empty, &skip_checks));
+        assert_eq!(expected, run(&empty, &skip_checks));
     }
 
     #[test]
@@ -110,7 +110,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -122,7 +122,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -131,7 +131,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -146,7 +146,7 @@ mod tests {
         let expected: Vec<Warning> = vec![warning];
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -161,7 +161,7 @@ mod tests {
         let expected: Vec<Warning> = vec![warning];
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
         let expected: Vec<Warning> = vec![warning];
         let skip_checks: Vec<&str> = vec!["KeyWithoutValue"];
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = vec!["KeyWithoutValue", "EndingBlankLine"];
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]

--- a/src/common.rs
+++ b/src/common.rs
@@ -184,7 +184,6 @@ mod tests {
 
         mod from {
             use super::*;
-            use std::fs::remove_file;
 
             #[test]
             fn path_without_file_test() {
@@ -203,7 +202,7 @@ mod tests {
                 assert_eq!(
                     Some((
                         FileEntry {
-                            path: path.clone(),
+                            path,
                             file_name,
                             total_lines: 0
                         },
@@ -211,7 +210,7 @@ mod tests {
                     )),
                     f
                 );
-                remove_file(path).expect("temp file deleted");
+                dir.close().expect("temp dir deleted");
             }
         }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -28,6 +28,10 @@ impl Warning {
     pub fn mark_as_fixed(&mut self) {
         self.is_fixed = true;
     }
+
+    pub fn mark_as_unfixed(&mut self) {
+        self.is_fixed = false;
+    }
 }
 
 impl fmt::Display for Warning {

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Warning {
-    check_name: String,
+    pub check_name: String,
     line: LineEntry,
     message: String,
+    pub is_fixed: bool,
 }
 
 impl Warning {
@@ -16,7 +17,16 @@ impl Warning {
             line,
             check_name,
             message,
+            is_fixed: false,
         }
+    }
+
+    pub fn line_number(&self) -> usize {
+        self.line.number
+    }
+
+    pub fn mark_as_fixed(&mut self) {
+        self.is_fixed = true;
     }
 }
 
@@ -174,7 +184,6 @@ mod tests {
 
         mod from {
             use super::*;
-            use std::env::temp_dir;
             use std::fs::remove_file;
 
             #[test]
@@ -186,7 +195,8 @@ mod tests {
             #[test]
             fn path_with_file_test() {
                 let file_name = String::from(".env");
-                let path = temp_dir().join(&file_name);
+                let dir = tempfile::tempdir().expect("create temp dir");
+                let path = dir.path().join(&file_name);
                 fs::File::create(&path).expect("create testfile");
 
                 let f = FileEntry::from(path.clone());

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -1,0 +1,134 @@
+use crate::common::*;
+
+mod lowercase_key;
+
+trait Fix {
+    fn name(&self) -> &str;
+
+    fn fix_warnings(
+        &self,
+        warnings: Vec<&mut Warning>,
+        lines: &mut Vec<LineEntry>,
+    ) -> Option<usize> {
+        let mut count: usize = 0;
+        for warning in warnings {
+            let line = &mut lines[warning.line_number() - 1];
+            if self.fix_line(line).is_some() {
+                warning.mark_as_fixed();
+                count += 1;
+            }
+        }
+
+        Some(count)
+    }
+
+    fn fix_line(&self, _line: &mut LineEntry) -> Option<()> {
+        None
+    }
+}
+
+// TODO: skip fixes (like checks)
+// The fix order is matter
+fn fixlist() -> Vec<Box<dyn Fix>> {
+    vec![
+        // At first we run the fixers that handle a single line entry (they use default
+        // implementation of the fix_warnings() function)
+        Box::new(lowercase_key::LowercaseKeyFixer::default()),
+        // Then we should run the fixers that handle the line entry collection at whole.
+        // And at the end we should run the fixer for ExtraBlankLine check (because the previous
+        // fixers can create additional extra blank lines).
+    ]
+}
+
+pub fn run(warnings: &mut [Warning], lines: &mut Vec<LineEntry>) -> usize {
+    if warnings.is_empty() {
+        return 0;
+    }
+
+    let mut count = 0;
+    for fixer in fixlist() {
+        // We can optimize it: create check_name:warnings map in advance
+        let fixer_warnings: Vec<&mut Warning> = warnings
+            .iter_mut()
+            .filter(|w| w.check_name == fixer.name())
+            .collect();
+        if !fixer_warnings.is_empty() {
+            count += fixer.fix_warnings(fixer_warnings, lines).unwrap_or(0);
+        }
+    }
+
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn line_entry(number: usize, total_lines: usize, str: &str) -> LineEntry {
+        LineEntry {
+            number,
+            file: FileEntry {
+                path: PathBuf::from(".env"),
+                file_name: ".env".to_string(),
+                total_lines,
+            },
+            raw_string: String::from(str),
+        }
+    }
+
+    fn blank_line_entry(number: usize, total_lines: usize) -> LineEntry {
+        LineEntry {
+            number,
+            file: FileEntry {
+                path: PathBuf::from(".env"),
+                file_name: ".env".to_string(),
+                total_lines,
+            },
+            raw_string: String::from("\n"),
+        }
+    }
+
+    #[test]
+    fn run_with_empty_warnings_test() {
+        let mut lines = vec![line_entry(1, 2, "A=B"), blank_line_entry(2, 2)];
+        let mut warnings: Vec<Warning> = Vec::new();
+
+        assert_eq!(0, run(&mut warnings, &mut lines));
+    }
+
+    #[test]
+    fn run_with_fixable_warning_test() {
+        let mut lines = vec![
+            line_entry(1, 3, "A=B"),
+            line_entry(2, 3, "c=d"),
+            blank_line_entry(3, 3),
+        ];
+        let mut warnings = vec![Warning::new(
+            lines[1].clone(),
+            "LowercaseKey",
+            String::from("The c key should be in uppercase"),
+        )];
+
+        assert_eq!(1, run(&mut warnings, &mut lines));
+        assert_eq!("C=d", lines[1].raw_string);
+        assert!(warnings[0].is_fixed);
+    }
+
+    #[test]
+    fn run_with_unfixable_warning_test() {
+        let mut lines = vec![
+            line_entry(1, 3, "A=B"),
+            line_entry(2, 3, "C"),
+            blank_line_entry(3, 3),
+        ];
+        let mut warnings = vec![Warning::new(
+            lines[1].clone(),
+            "KeyWithoutValue",
+            String::from("The C key should be with a value or have an equal sign"),
+        )];
+
+        assert_eq!(0, run(&mut warnings, &mut lines));
+        assert!(!warnings[0].is_fixed);
+    }
+}

--- a/src/fixes/lowercase_key.rs
+++ b/src/fixes/lowercase_key.rs
@@ -1,0 +1,93 @@
+use super::Fix;
+use crate::common::*;
+
+pub(crate) struct LowercaseKeyFixer<'a> {
+    name: &'a str,
+}
+
+impl Default for LowercaseKeyFixer<'_> {
+    fn default() -> Self {
+        Self {
+            name: "LowercaseKey",
+        }
+    }
+}
+
+impl Fix for LowercaseKeyFixer<'_> {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn fix_line(&self, line: &mut LineEntry) -> Option<()> {
+        let key = line.get_key()?;
+        let key = key.to_uppercase();
+        line.raw_string = format!("{}={}", key, line.get_value()?);
+
+        Some(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn fix_line_test() {
+        let fixer = LowercaseKeyFixer::default();
+        let mut line = LineEntry {
+            number: 1,
+            file: FileEntry {
+                path: PathBuf::from(".env"),
+                file_name: ".env".to_string(),
+                total_lines: 1,
+            },
+            raw_string: String::from("foO=BAR"),
+        };
+        assert_eq!(Some(()), fixer.fix_line(&mut line));
+        assert_eq!("FOO=BAR", line.raw_string);
+    }
+
+    #[test]
+    fn fix_warnings_test() {
+        let fixer = LowercaseKeyFixer::default();
+        let mut lines = vec![
+            LineEntry {
+                number: 1,
+                file: FileEntry {
+                    path: PathBuf::from(".env"),
+                    file_name: ".env".to_string(),
+                    total_lines: 3,
+                },
+                raw_string: String::from("foO=BAR"),
+            },
+            LineEntry {
+                number: 2,
+                file: FileEntry {
+                    path: PathBuf::from(".env"),
+                    file_name: ".env".to_string(),
+                    total_lines: 3,
+                },
+                raw_string: String::from("Z=Y"),
+            },
+            LineEntry {
+                number: 3,
+                file: FileEntry {
+                    path: PathBuf::from(".env"),
+                    file_name: ".env".to_string(),
+                    total_lines: 3,
+                },
+                raw_string: String::from("\n"),
+            },
+        ];
+        let mut warning = Warning::new(
+            lines[0].clone(),
+            "LowercaseKey",
+            String::from("The FOO key should be in uppercase"),
+        );
+
+        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
+        assert_eq!("FOO=BAR", lines[0].raw_string);
+        assert!(warning.is_fixed);
+    }
+}

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -51,7 +51,7 @@ pub fn write_file(path: &PathBuf, lines: Vec<LineEntry>) -> io::Result<()> {
 mod tests {
     use super::*;
     use crate::common::FileEntry;
-    use std::fs::{self, remove_file, File};
+    use std::fs::{self, File};
 
     fn run_relative_path_asserts(assertions: Vec<(&str, &str, &str)>) {
         for (target, base, relative) in assertions {
@@ -102,7 +102,7 @@ mod tests {
         // The result of `fs_utils` must match `std::fs` for non-Windows platform
         assert_eq!(canonical_path, fs_canonical_path);
 
-        remove_file(path).expect("temp file deleted");
+        dir.close().expect("temp dir deleted");
     }
 
     #[test]
@@ -127,7 +127,7 @@ mod tests {
         assert_eq!(canonical_path, dunce_canonical_path);
         assert!(!contains_unc);
 
-        remove_file(path).expect("temp file deleted");
+        dir.close().expect("temp dir deleted");
     }
 
     #[test]
@@ -166,6 +166,6 @@ mod tests {
             fs::read(path.as_path()).expect("file read").as_slice()
         );
 
-        remove_file(path).expect("temp file deleted");
+        dir.close().expect("temp dir deleted");
     }
 }

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -1,3 +1,6 @@
+use crate::common::LineEntry;
+use std::fs::File;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 /// For the Windows platform, we need to remove the UNC prefix.
@@ -31,11 +34,24 @@ pub fn get_relative_path(target_path: &PathBuf, base_path: &PathBuf) -> Option<P
     Some(relative_path)
 }
 
+/// In the future versions we should create a backup copy, or at least notify the user about it
+pub fn write_file(path: &PathBuf, lines: Vec<LineEntry>) -> io::Result<()> {
+    let mut file = File::create(path)?;
+
+    // We don't write the last line, because it contains only LF (common::FileEntry::from)
+    // and writeln! already adds LF.
+    for line in lines[..lines.len() - 1].iter() {
+        writeln!(file, "{}", line.raw_string)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env::temp_dir;
-    use std::fs::{remove_file, File};
+    use crate::common::FileEntry;
+    use std::fs::{self, remove_file, File};
 
     fn run_relative_path_asserts(assertions: Vec<(&str, &str, &str)>) {
         for (target, base, relative) in assertions {
@@ -76,7 +92,8 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn test_canonicalize() {
-        let path = temp_dir().join(".env");
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join(".env");
         File::create(&path).expect("file created");
 
         let fs_canonical_path = std::fs::canonicalize(&path).expect("canonical path by std::fs");
@@ -94,7 +111,8 @@ mod tests {
         const UNC_PREFIX: &str = "\\\\?\\";
 
         let file_name = String::from(".env");
-        let path = temp_dir().join(&file_name);
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join(&file_name);
         File::create(&path).expect("create testfile");
 
         let dunce_canonical_path = dunce::canonicalize(&path).expect("canonical path by `dunce`");
@@ -108,6 +126,45 @@ mod tests {
         // The result of `fs_utils` must match `dunce` on Windows
         assert_eq!(canonical_path, dunce_canonical_path);
         assert!(!contains_unc);
+
+        remove_file(path).expect("temp file deleted");
+    }
+
+    #[test]
+    fn write_file_test() {
+        let file_name = String::from(".env");
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join(&file_name);
+
+        let fe = FileEntry {
+            path: path.clone(),
+            file_name,
+            total_lines: 3,
+        };
+
+        let lines = vec![
+            LineEntry {
+                number: 1,
+                file: fe.clone(),
+                raw_string: String::from("A=B"),
+            },
+            LineEntry {
+                number: 2,
+                file: fe.clone(),
+                raw_string: String::from("Z=Y"),
+            },
+            LineEntry {
+                number: 3,
+                file: fe,
+                raw_string: String::from("\n"),
+            },
+        ];
+
+        assert!(write_file(&path, lines).is_ok());
+        assert_eq!(
+            b"A=B\nZ=Y\n",
+            fs::read(path.as_path()).expect("file read").as_slice()
+        );
 
         remove_file(path).expect("temp file deleted");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 mod checks;
 mod common;
+mod fixes;
 mod fs_utils;
 
 pub use checks::available_check_names;
@@ -35,6 +36,7 @@ pub fn run(args: clap::ArgMatches, current_dir: &PathBuf) -> Result<Vec<Warning>
         file_paths.extend(get_file_paths(input_paths, &excluded_paths, is_recursive));
     }
 
+    let is_fix = args.is_present("fix");
     let mut warnings: Vec<Warning> = Vec::new();
 
     for path in file_paths {
@@ -43,14 +45,18 @@ pub fn run(args: clap::ArgMatches, current_dir: &PathBuf) -> Result<Vec<Warning>
             None => continue,
         };
 
-        let file_with_lines = match FileEntry::from(relative_path) {
+        let (fe, strs) = match FileEntry::from(relative_path) {
             Some(f) => f,
             None => continue,
         };
 
-        let lines = get_line_entries(file_with_lines.0, file_with_lines.1);
+        let mut lines = get_line_entries(&fe, strs);
 
-        let result = checks::run(lines, &skip_checks);
+        let mut result = checks::run(&lines, &skip_checks);
+        if is_fix && fixes::run(&mut result, &mut lines) > 0 {
+            fs_utils::write_file(&fe.path, lines)?;
+        }
+
         warnings.extend(result);
     }
 
@@ -89,7 +95,7 @@ fn get_file_paths(
     file_paths
 }
 
-fn get_line_entries(fe: FileEntry, lines: Vec<String>) -> Vec<LineEntry> {
+fn get_line_entries(fe: &FileEntry, lines: Vec<String>) -> Vec<LineEntry> {
     let mut entries: Vec<LineEntry> = Vec::with_capacity(fe.total_lines);
 
     for (index, line) in lines.into_iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let warnings = dotenv_linter::run(args, &current_dir)?;
 
+    if warnings.is_empty() {
+        process::exit(0);
+    }
+
     if is_fix {
         if warnings.iter().any(|w| w.is_fixed) {
             println!("Fixed warnings:");
@@ -37,10 +41,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             process::exit(0);
         }
     } else {
-        if warnings.is_empty() {
-            process::exit(0);
-        }
-
         warnings.iter().for_each(|w| println!("{}", w));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,36 @@ fn main() -> Result<(), Box<dyn Error>> {
         process::exit(0);
     }
 
+    let is_fix = args.is_present("fix");
+
     let warnings = dotenv_linter::run(args, &current_dir)?;
-    if warnings.is_empty() {
-        process::exit(0);
+
+    if is_fix {
+        if warnings.iter().any(|w| w.is_fixed) {
+            println!("Fixed warnings:");
+            warnings
+                .iter()
+                .filter(|w| w.is_fixed)
+                .for_each(|w| println!("{}", w));
+        }
+
+        if warnings.iter().any(|w| !w.is_fixed) {
+            println!("\nUnfixed warnings:");
+            warnings
+                .iter()
+                .filter(|w| !w.is_fixed)
+                .for_each(|w| println!("{}", w));
+        } else {
+            process::exit(0);
+        }
+    } else {
+        if warnings.is_empty() {
+            process::exit(0);
+        }
+
+        warnings.iter().for_each(|w| println!("{}", w));
     }
 
-    warnings.iter().for_each(|w| println!("{}", w));
     process::exit(1);
 }
 
@@ -65,6 +89,12 @@ fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
                 .short("r")
                 .long("recursive")
                 .help("Recursively search and check .env files"),
+        )
+        .arg(
+            Arg::with_name("fix")
+                .short("f")
+                .long("fix")
+                .help("Automatically fixes warnings if possible"),
         )
         .get_matches()
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 mod args;
 mod checks;
 mod common;
+mod fixes;
 mod options;

--- a/tests/fixes/mod.rs
+++ b/tests/fixes/mod.rs
@@ -1,0 +1,73 @@
+use crate::common::TestDir;
+
+#[test]
+fn correct_file() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", "ABC=DEF\nD=BAR\n\nFOO=BAR\n");
+
+    testdir.test_command_fix_success(String::new());
+
+    assert_eq!(testfile.contents().as_str(), "ABC=DEF\nD=BAR\n\nFOO=BAR\n");
+
+    testdir.close();
+}
+
+#[test]
+fn lowercase_key() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", "abc=DEF\n\nfOO=BAR\n");
+    let expected_output = String::from(
+        "Fixed warnings:\n\
+        .env:1 LowercaseKey: The abc key should be in uppercase\n\
+        .env:3 LowercaseKey: The fOO key should be in uppercase\n",
+    );
+    testdir.test_command_fix_success(expected_output);
+
+    assert_eq!(testfile.contents().as_str(), "ABC=DEF\n\nFOO=BAR\n");
+
+    testdir.close();
+}
+
+#[test]
+fn unfixed_warnings() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", "A=DEF\nB=BAR \nf=BAR\n");
+
+    let expected_output = String::from(
+        "Fixed warnings:\n\
+        .env:3 LowercaseKey: The f key should be in uppercase\n\
+        \n\
+        Unfixed warnings:\n\
+        .env:2 TrailingWhitespace: Trailing whitespace detected\n",
+    );
+    testdir.test_command_fix_fail(expected_output);
+
+    assert_eq!(testfile.contents().as_str(), "A=DEF\nB=BAR \nF=BAR\n");
+
+    testdir.close();
+}
+
+#[test]
+fn multiple_files() {
+    let testdir = TestDir::new();
+
+    let testfile1 = testdir.create_testfile("1.env", "AB=DEF\nD=BAR\n\nF=BAR\n");
+    let testfile2 = testdir.create_testfile("2.env", "abc=DEF\n\nF=BAR\n");
+    let testfile3 = testdir.create_testfile("3.env", "A=b \nab=DEF\n");
+
+    let expected_output = String::from(
+        "Fixed warnings:\n\
+        2.env:1 LowercaseKey: The abc key should be in uppercase\n\
+        3.env:2 LowercaseKey: The ab key should be in uppercase\n\
+        \n\
+        Unfixed warnings:\n\
+        3.env:1 TrailingWhitespace: Trailing whitespace detected\n",
+    );
+    testdir.test_command_fix_fail(expected_output);
+
+    assert_eq!(testfile1.contents().as_str(), "AB=DEF\nD=BAR\n\nF=BAR\n");
+    assert_eq!(testfile2.contents().as_str(), "ABC=DEF\n\nF=BAR\n");
+    assert_eq!(testfile3.contents().as_str(), "A=b \nAB=DEF\n");
+
+    testdir.close();
+}


### PR DESCRIPTION
I have implemented automatic correction of the contents of files based on the results of the check.
When displaying, all warnings are marked as Fixed or Unfixed.
If all warnings are fixed, exit code is 0.

Just one kind of checks is fixable for now (LowercaseKey), but I have create the scaffold for implementing all kinds of checks.

The CLI key for the autofix mode is `-f`/`--fix`.

A few comments about the design:

The separate trait `Fix` was made for fixes (I tried to keep some symmetry with `checks`), but it is possible to expand the trait `Check` itself with this functions too.

There are two groups of fixes: some can be implemented by working only with the line that caused warning, for others you need to work with the entire line collection.

The `Fix` trait allows you to work with both groups of fixes due to default function implementations.

#### ✔ Checklist:

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).
