### PR TITLE
Remove `FileEntry::get_content_by_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add build and test steps running on Windows [#216](https://github.com/dotenv-linter/dotenv-linter/pull/216) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Remove `FileEntry::get_content_by_path` in favor of `fs::read_to_string` [#233](https://github.com/dotenv-linter/dotenv-linter/pull/233) ([@mstruebing](https://github.com/mstruebing))
 - Move show-checks flag to main.rs [#227](https://github.com/dotenv-linter/dotenv-linter/pull/227) ([@mgrachev](https://github.com/mgrachev))
 - Fix `total_lines` in some tests [#224](https://github.com/dotenv-linter/dotenv-linter/pull/224) ([@DDtKey](https://github.com/DDtKey))
 - Consider blank lines in `UnorderedKey` check [#221](https://github.com/dotenv-linter/dotenv-linter/pull/221) ([@mgrachev](https://github.com/mgrachev))

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,5 @@
 use std::fmt;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -48,9 +47,9 @@ impl FileEntry {
             None => return None,
         };
 
-        let content = match Self::get_content_by_path(&path) {
-            Some(s) => s,
-            None => return None,
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(_) => return None,
         };
 
         let mut lines: Vec<String> = content.lines().map(|str| str.to_string()).collect();
@@ -83,19 +82,6 @@ impl FileEntry {
             .map(|file_name| file_name.to_str())
             .unwrap_or(None)
             .map(|s| s.to_string())
-    }
-
-    fn get_content_by_path(path: &PathBuf) -> Option<String> {
-        let mut content = String::new();
-        let mut f = match File::open(&path) {
-            Ok(file) => file,
-            Err(_) => return None,
-        };
-
-        match f.read_to_string(&mut content) {
-            Ok(_) => Some(content),
-            Err(_) => None,
-        }
     }
 }
 
@@ -194,7 +180,7 @@ mod tests {
             fn path_with_file_test() {
                 let file_name = String::from(".env");
                 let path = temp_dir().join(&file_name);
-                File::create(&path).expect("create testfile");
+                fs::File::create(&path).expect("create testfile");
 
                 let f = FileEntry::from(path.clone());
                 assert_eq!(


### PR DESCRIPTION
in favor of `fs::read_to_string`

closes #232

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
