### PR TITLE
Add check_name to Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add build and test steps running on Windows [#216](https://github.com/dotenv-linter/dotenv-linter/pull/216) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Add the field with a checker name to Warning [#234](https://github.com/dotenv-linter/dotenv-linter/pull/234) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Remove `FileEntry::get_content_by_path` in favor of `fs::read_to_string` [#233](https://github.com/dotenv-linter/dotenv-linter/pull/233) ([@mstruebing](https://github.com/mstruebing))
 - Move show-checks flag to main.rs [#227](https://github.com/dotenv-linter/dotenv-linter/pull/227) ([@mgrachev](https://github.com/mgrachev))
 - Fix `total_lines` in some tests [#224](https://github.com/dotenv-linter/dotenv-linter/pull/224) ([@DDtKey](https://github.com/DDtKey))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -139,9 +139,8 @@ mod tests {
         let line = line_entry(1, 2, "FOO");
         let warning = Warning::new(
             line.clone(),
-            String::from(
-                "KeyWithoutValue: The FOO key should be with a value or have an equal sign",
-            ),
+            "KeyWithoutValue",
+            String::from("The FOO key should be with a value or have an equal sign"),
         );
         let lines: Vec<LineEntry> = vec![line, blank_line_entry(2, 2)];
         let expected: Vec<Warning> = vec![warning];
@@ -155,7 +154,8 @@ mod tests {
         let line = line_entry(1, 1, "FOO=BAR");
         let warning = Warning::new(
             line.clone(),
-            String::from("EndingBlankLine: No blank line at the end of the file"),
+            "EndingBlankLine",
+            String::from("No blank line at the end of the file"),
         );
         let lines: Vec<LineEntry> = vec![line];
         let expected: Vec<Warning> = vec![warning];
@@ -170,7 +170,8 @@ mod tests {
         let line2 = line_entry(2, 3, "1FOO\n");
         let warning = Warning::new(
             line2.clone(),
-            String::from("LeadingCharacter: Invalid leading character detected"),
+            "LeadingCharacter",
+            String::from("Invalid leading character detected"),
         );
         let lines: Vec<LineEntry> = vec![line1, line2, blank_line_entry(3, 3)];
         let expected: Vec<Warning> = vec![warning];

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -10,7 +10,7 @@ pub(crate) struct DuplicatedKeyChecker<'a> {
 
 impl DuplicatedKeyChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", &key))
+        self.template.replace("{}", &key)
     }
 }
 
@@ -29,7 +29,7 @@ impl Check for DuplicatedKeyChecker<'_> {
         let key = line.get_key()?;
 
         if self.keys.contains(&key) {
-            return Some(Warning::new(line.clone(), self.message(&key)));
+            return Some(Warning::new(line.clone(), self.name(), self.message(&key)));
         }
 
         self.keys.insert(key);
@@ -90,7 +90,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=BAR"),
                     },
-                    String::from("DuplicatedKey: The FOO key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The FOO key is duplicated"),
                 )),
             ),
         ];
@@ -165,7 +166,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=BAR"),
                     },
-                    String::from("DuplicatedKey: The FOO key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The FOO key is duplicated"),
                 )),
             ),
             (
@@ -200,7 +202,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("DuplicatedKey: The BAR key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The BAR key is duplicated"),
                 )),
             ),
         ];
@@ -243,7 +246,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=BAR"),
                     },
-                    String::from("DuplicatedKey: The FOO key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The FOO key is duplicated"),
                 )),
             ),
             (

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -17,14 +17,14 @@ impl Default for EndingBlankLineChecker<'_> {
 
 impl EndingBlankLineChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
 impl Check for EndingBlankLineChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if line.is_last_line() && !line.raw_string.ends_with(LF) {
-            Some(Warning::new(line.clone(), self.message()))
+            Some(Warning::new(line.clone(), self.name(), self.message()))
         } else {
             None
         }
@@ -91,7 +91,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("EndingBlankLine: No blank line at the end of the file"),
+            "EndingBlankLine",
+            String::from("No blank line at the end of the file"),
         ));
 
         assert_eq!(expected, checker.run(&line));

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -9,15 +9,15 @@ pub(crate) struct ExtraBlankLineChecker<'a> {
 
 impl ExtraBlankLineChecker<'_> {
     fn message(&self) -> String {
-        return format!("{}: {}", self.name, self.template);
+        String::from(self.template)
     }
 }
 
 impl Default for ExtraBlankLineChecker<'_> {
     fn default() -> Self {
         Self {
-            name: "ExtraBlankLine",
             template: "Extra blank line detected",
+            name: "ExtraBlankLine",
             last_blank_number: None,
         }
     }
@@ -35,7 +35,7 @@ impl Check for ExtraBlankLineChecker<'_> {
         self.last_blank_number = Some(line.number);
 
         if is_extra {
-            return Some(Warning::new(line.clone(), self.message()));
+            return Some(Warning::new(line.clone(), self.name(), self.message()));
         }
 
         None
@@ -65,7 +65,8 @@ mod tests {
                 },
                 raw_string: String::from(content),
             };
-            let expected = message.map(|msg| Warning::new(line.clone(), String::from(msg)));
+            let expected =
+                message.map(|msg| Warning::new(line.clone(), "ExtraBlankLine", String::from(msg)));
 
             assert_eq!(checker.run(&line), expected);
         }
@@ -90,7 +91,7 @@ mod tests {
         let asserts = vec![
             ("A=B", None),
             ("", None),
-            ("", Some("ExtraBlankLine: Extra blank line detected")),
+            ("", Some("Extra blank line detected")),
             ("C=D", None),
         ];
 
@@ -102,8 +103,8 @@ mod tests {
         let asserts = vec![
             ("A=B", None),
             ("", None),
-            ("", Some("ExtraBlankLine: Extra blank line detected")),
-            ("", Some("ExtraBlankLine: Extra blank line detected")),
+            ("", Some("Extra blank line detected")),
+            ("", Some("Extra blank line detected")),
             ("C=D", None),
         ];
 

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -8,7 +8,7 @@ pub(crate) struct IncorrectDelimiterChecker<'a> {
 
 impl IncorrectDelimiterChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", &key))
+        self.template.replace("{}", &key)
     }
 }
 
@@ -25,7 +25,7 @@ impl Check for IncorrectDelimiterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphanumeric() && c != '_') {
-            return Some(Warning::new(line.clone(), self.message(&key)));
+            return Some(Warning::new(line.clone(), self.name(), self.message(&key)));
         }
 
         None
@@ -85,7 +85,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("IncorrectDelimiter: The FOO-BAR key has incorrect delimiter"),
+            "IncorrectDelimiter",
+            String::from("The FOO-BAR key has incorrect delimiter"),
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -104,7 +105,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("IncorrectDelimiter: The FOO BAR key has incorrect delimiter"),
+            "IncorrectDelimiter",
+            String::from("The FOO BAR key has incorrect delimiter"),
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -17,14 +17,18 @@ impl Default for KeyWithoutValueChecker<'_> {
 
 impl KeyWithoutValueChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", &key))
+        self.template.replace("{}", &key)
     }
 }
 
 impl Check for KeyWithoutValueChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if !(line.is_empty() || line.raw_string.contains('=')) {
-            Some(Warning::new(line.clone(), self.message(&line.raw_string)))
+            Some(Warning::new(
+                line.clone(),
+                self.name(),
+                self.message(&line.raw_string),
+            ))
         } else {
             None
         }
@@ -99,9 +103,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from(
-                "KeyWithoutValue: The FOO key should be with a value or have an equal sign",
-            ),
+            "KeyWithoutValue",
+            String::from("The FOO key should be with a value or have an equal sign"),
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -17,7 +17,7 @@ impl Default for LeadingCharacterChecker<'_> {
 
 impl LeadingCharacterChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
@@ -30,7 +30,7 @@ impl Check for LeadingCharacterChecker<'_> {
         {
             None
         } else {
-            Some(Warning::new(line.clone(), self.message()))
+            Some(Warning::new(line.clone(), self.name(), self.message()))
         }
     }
 
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    const MESSAGE: &str = "LeadingCharacter: Invalid leading character detected";
+    const MESSAGE: &str = "Invalid leading character detected";
 
     #[test]
     fn normal() {
@@ -104,7 +104,11 @@ mod tests {
             raw_string: String::from(".FOO=BAR"),
         };
         assert_eq!(
-            Some(Warning::new(line.clone(), MESSAGE.to_string())),
+            Some(Warning::new(
+                line.clone(),
+                "LeadingCharacter",
+                MESSAGE.to_string()
+            )),
             checker.run(&line)
         );
     }
@@ -122,7 +126,11 @@ mod tests {
             raw_string: String::from("*FOO=BAR"),
         };
         assert_eq!(
-            Some(Warning::new(line.clone(), MESSAGE.to_string())),
+            Some(Warning::new(
+                line.clone(),
+                "LeadingCharacter",
+                MESSAGE.to_string()
+            )),
             checker.run(&line)
         );
     }
@@ -140,7 +148,11 @@ mod tests {
             raw_string: String::from("1FOO=BAR"),
         };
         assert_eq!(
-            Some(Warning::new(line.clone(), MESSAGE.to_string())),
+            Some(Warning::new(
+                line.clone(),
+                "LeadingCharacter",
+                MESSAGE.to_string()
+            )),
             checker.run(&line)
         );
     }
@@ -157,7 +169,11 @@ mod tests {
             },
             raw_string: String::from(" FOO=BAR"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "LeadingCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -173,7 +189,11 @@ mod tests {
             },
             raw_string: String::from("  FOO=BAR"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "LeadingCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -189,7 +209,11 @@ mod tests {
             },
             raw_string: String::from("\tFOO=BAR"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "LeadingCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -21,7 +21,7 @@ impl Check for LowercaseKeyChecker<'_> {
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line.clone(), self.message(&key)))
+            Some(Warning::new(line.clone(), self.name(), self.message(&key)))
         }
     }
 
@@ -32,7 +32,7 @@ impl Check for LowercaseKeyChecker<'_> {
 
 impl LowercaseKeyChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", key))
+        self.template.replace("{}", key)
     }
 }
 
@@ -70,7 +70,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("LowercaseKey: The foo_bar key should be in uppercase"),
+            "LowercaseKey",
+            String::from("The foo_bar key should be in uppercase"),
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -89,7 +90,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("LowercaseKey: The FOo_BAR key should be in uppercase"),
+            "LowercaseKey",
+            String::from("The FOo_BAR key should be in uppercase"),
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -8,7 +8,7 @@ pub(crate) struct QuoteCharacterChecker<'a> {
 
 impl QuoteCharacterChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
@@ -25,7 +25,7 @@ impl Check for QuoteCharacterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let val = line.get_value()?;
         if val.contains('\"') || val.contains('\'') {
-            Some(Warning::new(line.clone(), self.message()))
+            Some(Warning::new(line.clone(), self.name(), self.message()))
         } else {
             None
         }
@@ -85,7 +85,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO='BAR'"),
                     },
-                    String::from("QuoteCharacter: The value is wrapped in quotes"),
+                    "QuoteCharacter",
+                    String::from("The value is wrapped in quotes"),
                 )),
             ),
         ];
@@ -128,7 +129,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=\"BAR\""),
                     },
-                    String::from("QuoteCharacter: The value is wrapped in quotes"),
+                    "QuoteCharacter",
+                    String::from("The value is wrapped in quotes"),
                 )),
             ),
         ];

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -8,7 +8,7 @@ pub(crate) struct SpaceCharacterChecker<'a> {
 
 impl SpaceCharacterChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
@@ -27,7 +27,7 @@ impl Check for SpaceCharacterChecker<'_> {
 
         if let [key, value] = &line_splitted[..] {
             if key.ends_with(' ') || value.starts_with(' ') {
-                return Some(Warning::new(line.clone(), self.message()));
+                return Some(Warning::new(line.clone(), self.name(), self.message()));
             }
         }
 
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    const MESSAGE: &str = "SpaceCharacter: The line has spaces around equal sign";
+    const MESSAGE: &str = "The line has spaces around equal sign";
 
     #[test]
     fn working_run() {
@@ -133,7 +133,11 @@ mod tests {
             },
             raw_string: String::from("DEBUG-HTTP = true"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpaceCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -149,7 +153,11 @@ mod tests {
             },
             raw_string: String::from("DEBUG-HTTP =true"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpaceCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -165,7 +173,11 @@ mod tests {
             },
             raw_string: String::from("DEBUG-HTTP= true"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpaceCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -8,7 +8,7 @@ pub(crate) struct TrailingWhitespaceChecker<'a> {
 
 impl TrailingWhitespaceChecker<'_> {
     fn message(&self) -> String {
-        return format!("{}: {}", self.name, self.template);
+        String::from(self.template)
     }
 }
 
@@ -26,7 +26,7 @@ impl Check for TrailingWhitespaceChecker<'_> {
         let raw_string = &line.raw_string;
 
         if raw_string.ends_with(' ') {
-            return Some(Warning::new(line.clone(), self.message()));
+            return Some(Warning::new(line.clone(), self.name, self.message()));
         }
 
         None
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    const MESSAGE: &str = "TrailingWhitespace: Trailing whitespace detected";
+    const MESSAGE: &str = "Trailing whitespace detected";
 
     #[test]
     fn working_run() {
@@ -73,7 +73,11 @@ mod tests {
             raw_string: String::from("DEBUG_HTTP=true  "),
         };
 
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "TrailingWhitespace",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -9,21 +9,17 @@ pub(crate) struct UnorderedKeyChecker<'a> {
 
 impl UnorderedKeyChecker<'_> {
     fn message(&self, key_one: &str, key_two: &str) -> String {
-        return format!(
-            "{}: {}",
-            self.name,
-            self.template
-                .replace("{1}", key_one)
-                .replace("{2}", key_two)
-        );
+        self.template
+            .replace("{1}", key_one)
+            .replace("{2}", key_two)
     }
 }
 
 impl Default for UnorderedKeyChecker<'_> {
     fn default() -> Self {
         Self {
-            keys: Vec::new(),
             name: "UnorderedKey",
+            keys: Vec::new(),
             template: "The {1} key should go before the {2} key",
         }
     }
@@ -46,7 +42,7 @@ impl Check for UnorderedKeyChecker<'_> {
 
             let another_key = sorted_keys.get(index + 1)?;
 
-            let warning = Warning::new(line.clone(), self.message(&key, &another_key));
+            let warning = Warning::new(line.clone(), self.name(), self.message(&key, &another_key));
             return Some(warning);
         }
 
@@ -157,7 +153,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
         ];
@@ -200,7 +197,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -223,7 +221,8 @@ mod tests {
                         },
                         raw_string: String::from("ABC=BAR"),
                     },
-                    String::from("UnorderedKey: The ABC key should go before the BAR key"),
+                    "UnorderedKey",
+                    String::from("The ABC key should go before the BAR key"),
                 )),
             ),
         ];
@@ -266,7 +265,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -289,7 +289,8 @@ mod tests {
                         },
                         raw_string: String::from("DDD=BAR"),
                     },
-                    String::from("UnorderedKey: The DDD key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The DDD key should go before the FOO key"),
                 )),
             ),
         ];
@@ -332,7 +333,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -355,7 +357,8 @@ mod tests {
                         },
                         raw_string: String::from("DDD=BAR"),
                     },
-                    String::from("UnorderedKey: The DDD key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The DDD key should go before the FOO key"),
                 )),
             ),
             (

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,13 +4,19 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Warning {
+    pub check_name: String,
     line: LineEntry,
     message: String,
 }
 
 impl Warning {
-    pub fn new(line: LineEntry, message: String) -> Self {
-        Self { line, message }
+    pub fn new(line: LineEntry, check_name: &str, message: String) -> Self {
+        let check_name = String::from(check_name);
+        Self {
+            line,
+            check_name,
+            message,
+        }
     }
 }
 
@@ -18,8 +24,8 @@ impl fmt::Display for Warning {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}:{} {}",
-            self.line.file, self.line.number, self.message
+            "{}:{} {}: {}",
+            self.line.file, self.line.number, self.check_name, self.message
         )
     }
 }
@@ -153,7 +159,8 @@ mod tests {
         };
         let warning = Warning::new(
             line,
-            String::from("DuplicatedKey: The FOO key is duplicated"),
+            "DuplicatedKey",
+            String::from("The FOO key is duplicated"),
         );
 
         assert_eq!(

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Warning {
-    pub check_name: String,
+    check_name: String,
     line: LineEntry,
     message: String,
 }


### PR DESCRIPTION
I added the field with a checker name to `Warning` (it is possible to determine the checker by the text of the message, but I don't like this approach).

It is needed for the [Autofix](https://github.com/dotenv-linter/dotenv-linter/pull/228) feature.

#### ✔ Checklist:

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features).
