### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+
+### 🔧 Changed
+
+## [v2.1.0] - 2020-07-10
+### 🚀 Added
 - Add install.sh for provide more short way to install [#220](https://github.com/dotenv-linter/dotenv-linter/pull/220) ([@DDtKey](https://github.com/DDtKey))
 - Add flag to enable recursive search for `.env` files [#223](https://github.com/dotenv-linter/dotenv-linter/pull/223) ([@DDtKey](https://github.com/DDtKey))
 - Add docs [#226](https://github.com/dotenv-linter/dotenv-linter/pull/226) ([@wesleimp](https://github.com/wesleimp))
@@ -111,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace field warning with template for all check structs [#26](https://github.com/dotenv-linter/dotenv-linter/pull/26) ([@mgrachev](https://github.com/mgrachev))
 - Prepare a template for easy adding new checks [#14](https://github.com/dotenv-linter/dotenv-linter/pull/14) ([@mgrachev](https://github.com/mgrachev))
 
+[v2.1.0]: https://github.com/dotenv-linter/dotenv-linter/releases/tag/v2.1.0
 [v2.0.0]: https://github.com/dotenv-linter/dotenv-linter/releases/tag/v2.0.0
 [v1.2.0]: https://github.com/dotenv-linter/dotenv-linter/releases/tag/v1.2.0
 [v1.1.2]: https://github.com/dotenv-linter/dotenv-linter/releases/tag/v1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 
-## [v2.1.0] - 2020-07-10
+## [v2.1.0] - 2020-07-13
 ### 🚀 Added
 - Add install.sh for provide more short way to install [#220](https://github.com/dotenv-linter/dotenv-linter/pull/220) ([@DDtKey](https://github.com/DDtKey))
 - Add flag to enable recursive search for `.env` files [#223](https://github.com/dotenv-linter/dotenv-linter/pull/223) ([@DDtKey](https://github.com/DDtKey))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dotenv-linter"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotenv-linter"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Mikhail Grachev <work@mgrachev.com>"]
 edition = "2018"
 description = "Lightning-fast linter for .env files"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ trizen -S dotenv-linter-bin # for the binary distribution
 $ trizen -S dotenv-linter-git # for the current master branch
 ```
 
-### Windows / Scoop (will be available in [v2.1.0](https://github.com/dotenv-linter/dotenv-linter/issues/217))
+### Windows / Scoop
 
 ```shell script
 $ scoop bucket add dotenv-linter https://github.com/dotenv-linter/scoop.git
@@ -390,7 +390,7 @@ BAR=FOO
 FOO=BAR
 ```
 
-You can use blank lines to split lines into groups (will be available in [v2.1.0](https://github.com/dotenv-linter/dotenv-linter/issues/217)):
+You can use blank lines to split lines into groups:
 
 ```env
 ❌ Wrong

--- a/docs/checks/unordered_key.md
+++ b/docs/checks/unordered_key.md
@@ -12,7 +12,7 @@ BAR=FOO
 FOO=BAR
 ```
 
-You can use blank lines to split lines into groups (will be available in [v2.1.0](https://github.com/dotenv-linter/dotenv-linter/issues/217)):
+You can use blank lines to split lines into groups:
 
 ```env
 ❌ Wrong

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ $ trizen -S dotenv-linter-bin # for the binary distribution
 $ trizen -S dotenv-linter-git # for the current master branch
 ```
 
-**Windows / Scoop** (will be available in [v2.1.0](https://github.com/dotenv-linter/dotenv-linter/issues/217))
+**Windows / Scoop**
 
 ```shell script
 $ scoop bucket add dotenv-linter https://github.com/dotenv-linter/scoop.git


### PR DESCRIPTION
Just preparing for the release [v2.1.0](https://github.com/dotenv-linter/dotenv-linter/issues/217).
We also need to update the relevance: [homebrew-tap](https://github.com/dotenv-linter/homebrew-tap) and [action-dotenv-linter](https://github.com/dotenv-linter/action-dotenv-linter)