### PR TITLE
Add spaced-comment checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add spaced-comment checker [#241](https://github.com/dotenv-linter/dotenv-linter/pull/241) ([@wesleimp](https://github.com/wesleimp))
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It checks `.env` files for problems that may cause the application to malfunctio
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#lowercase-key">Lowercase key</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#quote-character">Quote character</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#space-character">Space character</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#spaced-comment">Spaced comment</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#trailing-whitespace">Trailing whitespace</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#unordered-Key">Unordered Key</a><br />
 </p>
@@ -205,6 +206,7 @@ LeadingCharacter
 LowercaseKey
 QuoteCharacter
 SpaceCharacter
+SpacedComment
 TrailingWhitespace
 UnorderedKey
 ```
@@ -370,6 +372,20 @@ FOO = BAR
 
 ✅ Correct
 FOO=BAR
+```
+
+### Spaced Comment
+
+Detects if there's a space after `#` in comment:
+
+```env
+❌ Wrong
+#Bad comment
+```
+
+```env
+✅ Correct
+# Good comment
 ```
 
 ### Trailing whitespace

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,6 +14,7 @@
 	* [Lowercase Key](checks/lowercase_key.md)
 	* [Quote Character](checks/quote_character.md)
 	* [Space Character](checks/space_character.md)
+	* [Spaced Comment](checks/spaced_comment.md)
 	* [Trailing whitespace](checks/trailing_whitespace.md)
 	* [Unordered Key](checks/unordered_key.md)
 

--- a/docs/checks/about.md
+++ b/docs/checks/about.md
@@ -12,6 +12,7 @@ Here is a list of avaliable checks for `dotenv_linter`:
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#/checks/lowercase_key">Lowercase key</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#/checks/quote_character">Quote character</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#/checks/space_character">Space character</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#/checks/spaced_comment">Spaced comment</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#/checks/trailing_whitespace">Trailing whitespace</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;✅&nbsp;<a href="#/checks/unordered_key">Unordered Key</a><br />
 </p>

--- a/docs/checks/spaced_comment.md
+++ b/docs/checks/spaced_comment.md
@@ -1,0 +1,13 @@
+# Spaced Comment
+
+Detects if there's a space after `#` in comment:
+
+```env
+❌ Wrong
+#Bad comment
+```
+
+```env
+✅ Correct
+# Good comment
+```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -59,6 +59,7 @@ LeadingCharacter
 LowercaseKey
 QuoteCharacter
 SpaceCharacter
+SpacedComment
 TrailingWhitespace
 UnorderedKey
 ```

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -9,6 +9,7 @@ mod leading_character;
 mod lowercase_key;
 mod quote_character;
 mod space_character;
+mod spaced_comment;
 mod trailing_whitespace;
 mod unordered_key;
 
@@ -33,6 +34,7 @@ fn checklist() -> Vec<Box<dyn Check>> {
         Box::new(lowercase_key::LowercaseKeyChecker::default()),
         Box::new(quote_character::QuoteCharacterChecker::default()),
         Box::new(space_character::SpaceCharacterChecker::default()),
+        Box::new(spaced_comment::SpacedCommentChecker::default()),
         Box::new(trailing_whitespace::TrailingWhitespaceChecker::default()),
         Box::new(unordered_key::UnorderedKeyChecker::default()),
     ]

--- a/src/checks/spaced_comment.rs
+++ b/src/checks/spaced_comment.rs
@@ -1,0 +1,85 @@
+use crate::checks::Check;
+use crate::common::*;
+
+pub(crate) struct SpacedCommentChecker<'a> {
+    name: &'a str,
+    template: &'a str,
+}
+
+impl Default for SpacedCommentChecker<'_> {
+    fn default() -> Self {
+        Self {
+            name: "SpacedComment",
+            template: "Expected space after '#' in comment",
+        }
+    }
+}
+
+impl SpacedCommentChecker<'_> {
+    fn message(&self) -> String {
+        String::from(self.template)
+    }
+}
+
+impl Check for SpacedCommentChecker<'_> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+        if line.is_comment() && !line.raw_string.starts_with("# ") {
+            return Some(Warning::new(line.clone(), self.name(), self.message()));
+        }
+
+        None
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn skip_comments(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    #[test]
+    fn with_space() {
+        let mut checker = SpacedCommentChecker::default();
+        let line = LineEntry {
+            number: 1,
+            file: FileEntry {
+                path: PathBuf::from(".env"),
+                file_name: ".env".to_string(),
+                total_lines: 1,
+            },
+
+            raw_string: String::from("# This is a good comment\n"),
+        };
+
+        assert_eq!(None, checker.run(&line));
+    }
+
+    #[test]
+    fn without_space() {
+        let mut checker = SpacedCommentChecker::default();
+        let line = LineEntry {
+            number: 1,
+            file: FileEntry {
+                path: PathBuf::from(".env"),
+                file_name: ".env".to_string(),
+                total_lines: 1,
+            },
+            raw_string: String::from("#This is a bad comment\n"),
+        };
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpacedComment",
+            String::from("Expected space after '#' in comment"),
+        ));
+
+        assert_eq!(expected, checker.run(&line));
+    }
+}


### PR DESCRIPTION
Add `SpacedCommentChecker` to check if there's a space after `#` in comment

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
