### PR TITLE
Add total problems to output and --quiet argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add --quiet argument [#242](https://github.com/dotenv-linter/dotenv-linter/pull/242) ([@mgrachev](https://github.com/mgrachev))
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Add --quiet argument [#242](https://github.com/dotenv-linter/dotenv-linter/pull/242) ([@mgrachev](https://github.com/mgrachev))
+- Add --quiet argument [#242](https://github.com/dotenv-linter/dotenv-linter/pull/242) ([@wesleimp](https://github.com/wesleimp), [@mgrachev](https://github.com/mgrachev))
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ UnorderedKey
 ```
 
 `dotenv-linter` can also automatically fix warnings in the files. Currently only one kind of warnings is fixed
-(`LowercaseKey`). You should use the argument `--fix` (or its short version `-f`) for this (will be available in [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/issues/238):
+(`LowercaseKey`). You should use the argument `--fix` (or its short version `-f`) for this (will be available in [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/issues/238)):
 
 ```shell script
 $ dotenv-linter -f

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ $ dotenv-linter
 .env:2 DuplicatedKey: The FOO key is duplicated
 .env:3 UnorderedKey: The BAR key should go before the FOO key
 .env.test:1 LeadingCharacter: Invalid leading character detected
+
+Found 3 problems
 ```
 
 To check another directory, just pass its path as an argument. The same approach works if you need to check any files individually:
@@ -167,6 +169,8 @@ $ dotenv-linter dir1 dir2/.my-env-file
 dir1/.env:1 LeadingCharacter: Invalid leading character detected
 dir1/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
 dir2/.my-env-file:1 LowercaseKey: The bar key should be in uppercase
+
+Found 3 problems
 ```
 
 If you need to exclude a file or directory from check, you can use the argument `--exclude PATH` or its short version `-e PATH`:
@@ -175,6 +179,8 @@ If you need to exclude a file or directory from check, you can use the argument 
 $ dotenv-linter --exclude .env.test
 .env:2 DuplicatedKey: The FOO key is duplicated
 .env:3 UnorderedKey: The BAR key should go before the FOO key
+
+Found 2 problems
 ```
 
 If you need a recursive `.env` file search inside directories, you can use the flag `--recursive` or its short version `-r`:
@@ -183,6 +189,8 @@ If you need a recursive `.env` file search inside directories, you can use the f
 $ dotenv-linter --recursive
 dir1/.env:2 DuplicatedKey: The FOO key is duplicated
 dir2/subdir/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
+
+Found 2 problems
 ```
 
 If you need to skip some checks, you can use the argument `--skip CHECK_NAME` or its short version `-s CHECK_NAME`:
@@ -190,6 +198,17 @@ If you need to skip some checks, you can use the argument `--skip CHECK_NAME` or
 ```shell script
 $ dotenv-linter --skip UnorderedKey EndingBlankLine
 .env:2 DuplicatedKey: The FOO key is duplicated
+
+Found 1 problem
+```
+
+If you want to see only warnings without additional information, use the argument `--quiet` or its short version `-q`:
+
+```shell script
+$ dotenv-linter --quiet
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+.env.test:1 LeadingCharacter: Invalid leading character detected
 ```
 
 If you need to view all available checks, you can use the flag `--show-checks`:

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -76,3 +76,15 @@ SpaceCharacter
 TrailingWhitespace
 UnorderedKey
 ```
+
+`dotenv-linter` can also automatically fix warnings in the files. Currently only one kind of warnings is fixed
+(`LowercaseKey`). You should use the argument `--fix` (or its short version `-f`) for this (will be available in [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/issues/238)):
+
+```shell script
+$ dotenv-linter -f
+Fixed warnings:
+.env:3 LowercaseKey: The foo key should be in uppercase
+
+Unfixed warnings:
+.env:2 DuplicatedKey: The BAR key is duplicated
+```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -4,29 +4,32 @@ By default, `dotenv-linter` checks all `.env` files in the current directory:
 
 ```sh
 $ dotenv-linter
-
 .env:2 DuplicatedKey: The FOO key is duplicated
 .env:3 UnorderedKey: The BAR key should go before the FOO key
 .env.test:1 LeadingCharacter: Invalid leading character detected
+
+Found 3 problems
 ```
 
 To check another directory, just pass its path as an argument. The same approach works if you need to check any files individually:
 
 ```sh
 $ dotenv-linter dir1 dir2/.my-env-file
-
 dir1/.env:1 LeadingCharacter: Invalid leading character detected
 dir1/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
 dir2/.my-env-file:1 LowercaseKey: The bar key should be in uppercase
+
+Found 3 problems
 ```
 
 If you need to exclude a file from check, you can use the argument `--exclude FILE_PATH` or its short version `-e FILE_PATH`:
 
 ```sh
 $ dotenv-linter --exclude .env.test
-
 .env:2 DuplicatedKey: The FOO key is duplicated
 .env:3 UnorderedKey: The BAR key should go before the FOO key
+
+Found 2 problems
 ```
 
 If you need a recursive search inside directories (deeper than 1 level), you can use the flag `--recursive` or its short version `-r`:
@@ -35,21 +38,32 @@ If you need a recursive search inside directories (deeper than 1 level), you can
 $ dotenv-linter --recursive
 dir1/.env:2 DuplicatedKey: The FOO key is duplicated
 dir2/subdir/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
+
+Found 2 problems
 ```
 
 If you need to skip some checks, you can use the argument `--skip CHECK_NAME` or its short version `-s CHECK_NAME`:
 
 ```sh
 $ dotenv-linter --skip UnorderedKey EndingBlankLine
-
 .env:2 DuplicatedKey: The FOO key is duplicated
+
+Found 1 problem
+```
+
+If you want to see only warnings without additional information, use the argument `--quiet` or its short version `-q`:
+
+```shell script
+$ dotenv-linter --quiet
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+.env.test:1 LeadingCharacter: Invalid leading character detected
 ```
 
 If you need to view all available checks, you can use the argument `--show-checks`:
 
 ```sh
 $ dotenv-linter --show-checks
-
 DuplicatedKey
 EndingBlankLine
 ExtraBlankLine

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod fs_utils;
 pub use checks::available_check_names;
 
 #[allow(clippy::redundant_closure)]
-pub fn run(args: clap::ArgMatches, current_dir: &PathBuf) -> Result<Vec<Warning>, Box<dyn Error>> {
+pub fn run(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<Vec<Warning>, Box<dyn Error>> {
     let mut file_paths: Vec<PathBuf> = Vec::new();
     let mut skip_checks: Vec<&str> = Vec::new();
     let mut excluded_paths: Vec<PathBuf> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,28 @@ fn main() -> Result<(), Box<dyn Error>> {
         process::exit(0);
     }
 
-    let warnings = dotenv_linter::run(args, &current_dir)?;
+    let warnings = dotenv_linter::run(&args, &current_dir)?;
     if warnings.is_empty() {
         process::exit(0);
     }
 
     warnings.iter().for_each(|w| println!("{}", w));
+
+    if !args.is_present("quiet") {
+        print_total(warnings.len());
+    }
+
     process::exit(1);
+}
+
+fn print_total(total_problems: usize) {
+    let mut problems = String::from("problem");
+
+    if total_problems > 1 {
+        problems = problems + "s";
+    }
+
+    println!("\n{}", format!("Found {} {}", total_problems, problems));
 }
 
 fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
@@ -65,6 +80,12 @@ fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
                 .short("r")
                 .long("recursive")
                 .help("Recursively search and check .env files"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .long("quiet")
+                .help("Don't display additional information"),
         )
         .get_matches()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,14 +28,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     process::exit(1);
 }
 
-fn print_total(total_problems: usize) {
+fn print_total(total: usize) {
     let mut problems = String::from("problem");
 
-    if total_problems > 1 {
+    if total > 1 {
         problems += "s";
     }
 
-    println!("\n{}", format!("Found {} {}", total_problems, problems));
+    println!("\n{}", format!("Found {} {}", total, problems));
 }
 
 fn get_args(current_dir: &OsStr) -> clap::ArgMatches {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     } else {
         warnings.iter().for_each(|w| println!("{}", w));
-    }
-      
-    if !args.is_present("quiet") {
-        print_total(warnings.len());
+
+        if !args.is_present("quiet") {
+            print_total(warnings.len());
+        }
     }
 
     process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn print_total(total_problems: usize) {
     let mut problems = String::from("problem");
 
     if total_problems > 1 {
-        problems = problems + "s";
+        problems += "s";
     }
 
     println!("\n{}", format!("Found {} {}", total_problems, problems));

--- a/tests/args/current_dir.rs
+++ b/tests/args/current_dir.rs
@@ -12,10 +12,12 @@ fn checks_current_dir() {
     let testdir = TestDir::new();
     let testfile = testdir.create_testfile(".env", "FOO\n");
 
-    testdir.test_command_fail(format!(
-        "{}:1 KeyWithoutValue: The FOO key should be with a value or have an equal sign\n",
-        testfile.shortname_as_str()
-    ));
+    testdir.test_command_fail(
+        format!(
+            "{}:1 KeyWithoutValue: The FOO key should be with a value or have an equal sign\n\nFound 1 problem\n",
+            testfile.shortname_as_str()
+        )
+    );
 }
 
 #[test]
@@ -25,7 +27,7 @@ fn checks_current_dir_with_dot_arg() {
 
     let args = &["."];
     let expected_output = format!(
-        "{}:1 LowercaseKey: The foo key should be in uppercase\n",
+        "{}:1 LowercaseKey: The foo key should be in uppercase\n\nFound 1 problem\n",
         testfile.shortname_as_str(),
     );
 

--- a/tests/args/specific_path.rs
+++ b/tests/args/specific_path.rs
@@ -11,7 +11,7 @@ fn checks_one_specific_path() {
 
     let args = &[subdir.as_str()];
     let expected_output = format!(
-        "{}:1 LeadingCharacter: Invalid leading character detected\n",
+        "{}:1 LeadingCharacter: Invalid leading character detected\n\nFound 1 problem\n",
         Path::new(&testdir.relative_path(&subdir))
             .join(testfile_2.shortname_as_str())
             .to_str()
@@ -34,7 +34,7 @@ fn checks_two_specific_paths() {
 
     let args = &[subdir_1.as_str(), subdir_2.as_str()];
     let expected_output = format!(
-        "{}:1 LeadingCharacter: Invalid leading character detected\n{}:1 LeadingCharacter: Invalid leading character detected\n",
+        "{}:1 LeadingCharacter: Invalid leading character detected\n{}:1 LeadingCharacter: Invalid leading character detected\n\nFound 2 problems\n",
         Path::new(&testdir.relative_path(&subdir_1))
             .join(testfile_2.shortname_as_str())
             .to_str().expect("multi-platform path to test .env file"),
@@ -54,7 +54,7 @@ fn checks_one_specific_file() {
 
     let args = &[testfile_2.as_str()];
     let expected_output = format!(
-        "{}:1 SpaceCharacter: The line has spaces around equal sign\n",
+        "{}:1 SpaceCharacter: The line has spaces around equal sign\n\nFound 1 problem\n",
         testfile_2.shortname_as_str()
     );
 
@@ -72,7 +72,7 @@ fn checks_two_specific_files() {
 
     let args = &[testfile_2.as_str(), testfile_3.as_str()];
     let expected_output = format!(
-        "{}:2 DuplicatedKey: The FOO key is duplicated\n{}:1 SpaceCharacter: The line has spaces around equal sign\n",
+        "{}:2 DuplicatedKey: The FOO key is duplicated\n{}:1 SpaceCharacter: The line has spaces around equal sign\n\nFound 2 problems\n",
         Path::new(&testdir.relative_path(&subdir))
             .join(testfile_3.shortname_as_str())
             .to_str().expect("multi-platform path to test .env file"),
@@ -93,7 +93,7 @@ fn checks_one_specific_file_and_one_path() {
 
     let args = &[testfile_2.as_str(), subdir.as_str()];
     let expected_output = format!(
-        "{}:2 UnorderedKey: The BAR key should go before the FOO key\n{}:2 DuplicatedKey: The FOO key is duplicated\n",
+        "{}:2 UnorderedKey: The BAR key should go before the FOO key\n{}:2 DuplicatedKey: The FOO key is duplicated\n\nFound 2 problems\n",
         testfile_2.shortname_as_str(),
         Path::new(&testdir.relative_path(&subdir))
             .join(testfile_3.shortname_as_str())
@@ -111,7 +111,7 @@ fn checks_one_specific_file_twice() {
 
     let args = &[testfile_2.as_str(), testfile_2.as_str()];
     let expected_output = format!(
-        "{}:1 LeadingCharacter: Invalid leading character detected\n",
+        "{}:1 LeadingCharacter: Invalid leading character detected\n\nFound 1 problem\n",
         testfile_2.shortname_as_str()
     );
 

--- a/tests/checks/ending_blank_line.rs
+++ b/tests/checks/ending_blank_line.rs
@@ -32,7 +32,7 @@ fn incorrect_files() {
         let testfile = testdir.create_testfile(".env", content);
         let args = &[testfile.as_str()];
         let expected_output = format!(
-            "{}:{} EndingBlankLine: No blank line at the end of the file\n",
+            "{}:{} EndingBlankLine: No blank line at the end of the file\n\nFound 1 problem\n",
             testfile.shortname_as_str(),
             expected_line_numbers[i]
         );

--- a/tests/checks/extra_blank_line.rs
+++ b/tests/checks/extra_blank_line.rs
@@ -25,7 +25,7 @@ fn two_blank_lines_at_the_beginning() {
     let testfile = testdir.create_testfile(".env", content);
     let args = &[testfile.as_str()];
     let expected_output = format!(
-        "{}:{} ExtraBlankLine: Extra blank line detected\n",
+        "{}:{} ExtraBlankLine: Extra blank line detected\n\nFound 1 problem\n",
         testfile.shortname_as_str(),
         2
     );
@@ -41,7 +41,7 @@ fn two_blank_lines_in_the_middle() {
     let testfile = testdir.create_testfile(".env", content);
     let args = &[testfile.as_str()];
     let expected_output = format!(
-        "{}:{} ExtraBlankLine: Extra blank line detected\n",
+        "{}:{} ExtraBlankLine: Extra blank line detected\n\nFound 1 problem\n",
         testfile.shortname_as_str(),
         4
     );
@@ -57,7 +57,7 @@ fn two_blank_lines_at_the_end() {
     let testfile = testdir.create_testfile(".env", content);
     let args = &[testfile.as_str()];
     let expected_output = format!(
-        "{}:{} ExtraBlankLine: Extra blank line detected\n",
+        "{}:{} ExtraBlankLine: Extra blank line detected\n\nFound 1 problem\n",
         testfile.shortname_as_str(),
         5
     );

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 mod args;
 mod checks;
 mod common;
+mod flags;
 mod options;

--- a/tests/flags/mod.rs
+++ b/tests/flags/mod.rs
@@ -1,0 +1,2 @@
+mod quiet;
+mod recursive;

--- a/tests/flags/quiet.rs
+++ b/tests/flags/quiet.rs
@@ -1,0 +1,15 @@
+use crate::common::TestDir;
+
+#[test]
+fn output_without_total() {
+    let test_dir = TestDir::new();
+    let testfile_to_check = test_dir.create_testfile(".env", " BAR='Baz'\n");
+
+    let args = &["--quiet"];
+    let expected_output = format!(
+        "{a}:1 LeadingCharacter: Invalid leading character detected\n{a}:1 QuoteCharacter: The value is wrapped in quotes\n",
+        a=testfile_to_check.shortname_as_str()
+    );
+
+    test_dir.test_command_fail_with_args(args, expected_output);
+}

--- a/tests/flags/recursive.rs
+++ b/tests/flags/recursive.rs
@@ -10,7 +10,7 @@ fn checks_one_in_subdir() {
 
     let args = &["-r"];
     let expected_output = format!(
-        "{}:1 LeadingCharacter: Invalid leading character detected\n",
+        "{}:1 LeadingCharacter: Invalid leading character detected\n\nFound 1 problem\n",
         Path::new(&test_dir.relative_path(&test_subdir))
             .join(testfile_2.shortname_as_str())
             .to_str()
@@ -33,7 +33,7 @@ fn checks_files_in_deep_subdirs() {
 
     let args = &["--recursive"];
     let expected_output = format!(
-        "{}:2 UnorderedKey: The BAR key should go before the FOO key\n{}:1 EndingBlankLine: No blank line at the end of the file\n",
+        "{}:2 UnorderedKey: The BAR key should go before the FOO key\n{}:1 EndingBlankLine: No blank line at the end of the file\n\nFound 2 problems\n",
         Path::new(&test_dir.relative_path(&test_subdir_2))
             .join(testfile_2.shortname_as_str())
             .to_str()
@@ -71,7 +71,7 @@ fn checks_recursive_with_exclude_subdir() {
 
     let args = &["--exclude", testfile_to_exclude.as_str(), "--recursive"];
     let expected_output = format!(
-        "{}:2 UnorderedKey: The BAR key should go before the FOO key\n",
+        "{}:2 UnorderedKey: The BAR key should go before the FOO key\n\nFound 1 problem\n",
         Path::new(&test_dir.relative_path(&test_subdir_2))
             .join(testfile_2.shortname_as_str())
             .to_str()

--- a/tests/options/exclude.rs
+++ b/tests/options/exclude.rs
@@ -29,7 +29,7 @@ fn exclude_one_file_check_one_file() {
 
     let args = &["--exclude", testfile_to_exclude.as_str()];
     let expected_output = format!(
-        "{}:1 LeadingCharacter: Invalid leading character detected\n",
+        "{}:1 LeadingCharacter: Invalid leading character detected\n\nFound 1 problem\n",
         testfile_to_check.shortname_as_str()
     );
 

--- a/tests/options/mod.rs
+++ b/tests/options/mod.rs
@@ -1,2 +1,1 @@
 mod exclude;
-mod recursive;


### PR DESCRIPTION
This PR originates from #240.  
I decided to add an additional flag to be able not to display verbose information such as "Found n problems".
In #240 PR uses the flag `--no-color` for this, but I think we should add the additional flag `--quiet`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
