### PR TITLE
Add trailing whitespace fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add autofix for TrailingWhitespace [#255](https://github.com/dotenv-linter/dotenv-linter/pull/255) ([@gregcline](https://github.com/gregcline))
 - Add total problems to output and `--quiet` argument [#242](https://github.com/dotenv-linter/dotenv-linter/pull/242) ([@wesleimp](https://github.com/wesleimp), [@mgrachev](https://github.com/mgrachev))
 - Add autofix feature (for LowercaseKey check) [#228](https://github.com/dotenv-linter/dotenv-linter/pull/228) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -1,6 +1,7 @@
 use crate::common::*;
 
 mod lowercase_key;
+mod trailing_whitespace;
 
 trait Fix {
     fn name(&self) -> &str;
@@ -34,6 +35,7 @@ fn fixlist() -> Vec<Box<dyn Fix>> {
         // At first we run the fixers that handle a single line entry (they use default
         // implementation of the fix_warnings() function)
         Box::new(lowercase_key::LowercaseKeyFixer::default()),
+        Box::new(trailing_whitespace::TrailingWhitespaceFixer::default()),
         // Then we should run the fixers that handle the line entry collection at whole.
         // And at the end we should run the fixer for ExtraBlankLine check (because the previous
         // fixers can create additional extra blank lines).

--- a/src/fixes/trailing_whitespace.rs
+++ b/src/fixes/trailing_whitespace.rs
@@ -1,0 +1,93 @@
+use super::Fix;
+use crate::common::*;
+
+pub(crate) struct TrailingWhitespaceFixer<'a> {
+    name: &'a str,
+}
+
+impl Default for TrailingWhitespaceFixer<'_> {
+    fn default() -> Self {
+        Self {
+            name: "TrailingWhitespace",
+        }
+    }
+}
+
+impl Fix for TrailingWhitespaceFixer<'_> {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn fix_line(&self, line: &mut LineEntry) -> Option<()> {
+        line.raw_string = line.raw_string.trim_end().to_string();
+
+        Some(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn fix_line_test() {
+        let fixer = TrailingWhitespaceFixer::default();
+
+        let mut line = LineEntry {
+            number: 1,
+            file: FileEntry {
+                path: PathBuf::from(".env"),
+                file_name: ".env".to_string(),
+                total_lines: 1,
+            },
+            raw_string: String::from("DEBUG_HTTP=true  "),
+        };
+
+        assert_eq!(Some(()), fixer.fix_line(&mut line));
+        assert_eq!("DEBUG_HTTP=true", line.raw_string);
+    }
+
+    #[test]
+    fn fix_warnings_test() {
+        let fixer = TrailingWhitespaceFixer::default();
+        let mut lines = vec![
+            LineEntry {
+                number: 1,
+                file: FileEntry {
+                    path: PathBuf::from(".env"),
+                    file_name: ".env".to_string(),
+                    total_lines: 3,
+                },
+                raw_string: String::from("FOO=BAR "),
+            },
+            LineEntry {
+                number: 2,
+                file: FileEntry {
+                    path: PathBuf::from(".env"),
+                    file_name: ".env".to_string(),
+                    total_lines: 3,
+                },
+                raw_string: String::from("Z=Y"),
+            },
+            LineEntry {
+                number: 3,
+                file: FileEntry {
+                    path: PathBuf::from(".env"),
+                    file_name: ".env".to_string(),
+                    total_lines: 3,
+                },
+                raw_string: String::from("\n"),
+            },
+        ];
+        let mut warning = Warning::new(
+            lines[0].clone(),
+            "TrailingWhitespace",
+            String::from("Trailing whitespace detected"),
+        );
+
+        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
+        assert_eq!("FOO=BAR", lines[0].raw_string);
+        assert!(warning.is_fixed);
+    }
+}

--- a/tests/fixes/mod.rs
+++ b/tests/fixes/mod.rs
@@ -1,6 +1,7 @@
 use crate::common::TestDir;
 
 mod space_character;
+mod trailing_whitespace;
 
 #[test]
 fn correct_file() {

--- a/tests/fixes/mod.rs
+++ b/tests/fixes/mod.rs
@@ -31,18 +31,19 @@ fn lowercase_key() {
 #[test]
 fn unfixed_warnings() {
     let testdir = TestDir::new();
-    let testfile = testdir.create_testfile(".env", "A=DEF\nB=BAR \nf=BAR\n");
+    let testfile = testdir.create_testfile(".env", "A=DEF\nB=BAR \nf=BAR\n\n");
 
     let expected_output = String::from(
         "Fixed warnings:\n\
+        .env:2 TrailingWhitespace: Trailing whitespace detected\n\
         .env:3 LowercaseKey: The f key should be in uppercase\n\
         \n\
         Unfixed warnings:\n\
-        .env:2 TrailingWhitespace: Trailing whitespace detected\n",
+        .env:5 ExtraBlankLine: Extra blank line detected\n",
     );
     testdir.test_command_fix_fail(expected_output);
 
-    assert_eq!(testfile.contents().as_str(), "A=DEF\nB=BAR \nF=BAR\n");
+    assert_eq!(testfile.contents().as_str(), "A=DEF\nB=BAR\nF=BAR\n\n");
 
     testdir.close();
 }
@@ -53,21 +54,22 @@ fn multiple_files() {
 
     let testfile1 = testdir.create_testfile("1.env", "AB=DEF\nD=BAR\n\nF=BAR\n");
     let testfile2 = testdir.create_testfile("2.env", "abc=DEF\n\nF=BAR\n");
-    let testfile3 = testdir.create_testfile("3.env", "A=b \nab=DEF\n");
+    let testfile3 = testdir.create_testfile("3.env", "A=b \nab=DEF\n\n");
 
     let expected_output = String::from(
         "Fixed warnings:\n\
         2.env:1 LowercaseKey: The abc key should be in uppercase\n\
+        3.env:1 TrailingWhitespace: Trailing whitespace detected\n\
         3.env:2 LowercaseKey: The ab key should be in uppercase\n\
         \n\
         Unfixed warnings:\n\
-        3.env:1 TrailingWhitespace: Trailing whitespace detected\n",
+        3.env:4 ExtraBlankLine: Extra blank line detected\n",
     );
     testdir.test_command_fix_fail(expected_output);
 
     assert_eq!(testfile1.contents().as_str(), "AB=DEF\nD=BAR\n\nF=BAR\n");
     assert_eq!(testfile2.contents().as_str(), "ABC=DEF\n\nF=BAR\n");
-    assert_eq!(testfile3.contents().as_str(), "A=b \nAB=DEF\n");
+    assert_eq!(testfile3.contents().as_str(), "A=b\nAB=DEF\n\n");
 
     testdir.close();
 }

--- a/tests/fixes/trailing_whitespace.rs
+++ b/tests/fixes/trailing_whitespace.rs
@@ -1,0 +1,17 @@
+use crate::common::TestDir;
+
+#[test]
+fn trailing_whitespace() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", "ABC=DEF \n\nFOO=BAR   \n");
+    let expected_output = String::from(
+        "Fixed warnings:\n\
+        .env:1 TrailingWhitespace: Trailing whitespace detected\n\
+        .env:3 TrailingWhitespace: Trailing whitespace detected\n",
+    );
+    testdir.test_command_fix_success(expected_output);
+
+    assert_eq!(testfile.contents().as_str(), "ABC=DEF\n\nFOO=BAR\n");
+
+    testdir.close();
+}


### PR DESCRIPTION
Add `TrailingWhitespaceFixer` and included it in the `fixlist`.

Update `unfixed_warnings` and `multiple_files` tests to reflect the new
fix and to use `ExtraBlankLine` as an unfixed warning example.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
