### PR TITLE
Output file names scanned (#268)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@ pub fn run(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<Vec<Warning
             None => continue,
         };
 
+        println!("Linting {:?}", fe.path.as_os_str());
+
         let mut lines = get_line_entries(&fe, strs);
 
         let mut result = checks::run(&lines, &skip_checks);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if is_fix {
         if warnings.iter().any(|w| w.is_fixed) {
-            println!("Fixed warnings:");
+            println!("\nFixed warnings:");
             warnings
                 .iter()
                 .filter(|w| w.is_fixed)
@@ -41,6 +41,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             process::exit(0);
         }
     } else {
+        println!("\nWarnings Found:");
         warnings.iter().for_each(|w| println!("{}", w));
 
         if !args.is_present("quiet") {


### PR DESCRIPTION
Closes #268 

Output the file names that are being linted / scanned. I ran in recursive mode to see the walk of scanning in progress, quite handy.

Output:
```
Linting "test.env"
Linting "tests/test.env"
Linting "tests/fixes/test.env"

Warnings Found:
test.env:1 IncorrectDelimiter: The HELLO-WORLD key has incorrect delimiter
tests/test.env:1 IncorrectDelimiter: The HELLO-WORLD key has incorrect delimiter
tests/fixes/test.env:1 IncorrectDelimiter: The HELLO-WORLD key has incorrect delimiter

Found 3 problems
```

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
