### PR TITLE
Partition fixed/unfixed warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
+- Partition fixed/unfixed warnings [#275](https://github.com/dotenv-linter/dotenv-linter/pull/275) ([@gillespiecd](https://github.com/gillespiecd))
 - Add missing test for IncorrectDelimiterChecker [#273](https://github.com/dotenv-linter/dotenv-linter/pull/273) ([@mgrachev](https://github.com/mgrachev))
 - Add *.env to gitignore [#271](https://github.com/dotenv-linter/dotenv-linter/pull/271) ([@baile320](https://github.com/baile320))
 - Actions uses cache@v2 [#262](https://github.com/dotenv-linter/dotenv-linter/pull/262) ([@gillespiecd](https://github.com/gillespiecd))

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,29 +14,29 @@ fn main() -> Result<(), Box<dyn Error>> {
         process::exit(0);
     }
 
-    let is_fix = args.is_present("fix");
-
     let warnings = dotenv_linter::run(&args, &current_dir)?;
 
     if warnings.is_empty() {
         process::exit(0);
     }
 
+    let is_fix = args.is_present("fix");
+
     if is_fix {
-        if warnings.iter().any(|w| w.is_fixed) {
+        let (fixed, unfixed): (Vec<_>, Vec<_>) = warnings.iter().partition(|w| w.is_fixed);
+
+        if !fixed.is_empty() {
             println!("Fixed warnings:");
-            warnings
-                .iter()
-                .filter(|w| w.is_fixed)
-                .for_each(|w| println!("{}", w));
+            for w in fixed {
+                println!("{}", w);
+            }
         }
 
-        if warnings.iter().any(|w| !w.is_fixed) {
+        if !unfixed.is_empty() {
             println!("\nUnfixed warnings:");
-            warnings
-                .iter()
-                .filter(|w| !w.is_fixed)
-                .for_each(|w| println!("{}", w));
+            for w in unfixed {
+                println!("{}", w);
+            }
         } else {
             process::exit(0);
         }


### PR DESCRIPTION
1. Small refactor to bucket the warnings vector into fixed/unfixed using a `partition` closure.

In my opinion, this seems clearer to read and more idiomatic than running two separate filter iterations.

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
