### PR TITLE
Group lines by control comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
+- Change the line grouping for the `UnorderedKey` checker [#281](https://github.com/dotenv-linter/dotenv-linter/pull/281) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Fix a bug with `ExtraBlankLineFixer` and control comments [#279](https://github.com/dotenv-linter/dotenv-linter/pull/279) ([@mgrachev](https://github.com/mgrachev))
 - Move logic for creating `LineEntry` for tests to `common` module [#280](https://github.com/dotenv-linter/dotenv-linter/pull/280) ([@mgrachev](https://github.com/mgrachev))
 - Simplify UnorderedKeyChecker [#277](https://github.com/dotenv-linter/dotenv-linter/pull/277) ([@mgrachev](https://github.com/mgrachev))

--- a/README.md
+++ b/README.md
@@ -449,6 +449,19 @@ FOO=BAR
 BAR=FOO
 ```
 
+Control comments also split lines (this is done to make the linter logic more predictable):
+
+```env
+❌ Wrong
+FOO=BAR
+BAR=FOO
+
+✅ Correct 
+FOO=BAR
+# dotenv-linter:off LowercaseKey
+bar=FOO
+```
+
 ## 🤝 Contributing
 
 If you've ever wanted to contribute to open source, now you have a great opportunity:

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ FOO=BAR
 BAR=FOO
 ```
 
-Control comments also split lines (this is done to make the linter logic more predictable):
+Control comments also split lines (this is done to make the linter logic more predictable, will be available in [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/issues/238)):
 
 ```env
 ❌ Wrong

--- a/docs/checks/unordered_key.md
+++ b/docs/checks/unordered_key.md
@@ -25,7 +25,7 @@ FOO=BAR
 BAR=FOO
 ```
 
-Control comments also split lines (this is done to make the linter logic more predictable):
+Control comments also split lines (this is done to make the linter logic more predictable, will be available in [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/issues/238)):
 
 ```env
 ❌ Wrong

--- a/docs/checks/unordered_key.md
+++ b/docs/checks/unordered_key.md
@@ -24,3 +24,16 @@ FOO=BAR
 
 BAR=FOO
 ```
+
+Control comments also split lines (this is done to make the linter logic more predictable):
+
+```env
+❌ Wrong
+FOO=BAR
+BAR=FOO
+
+✅ Correct 
+FOO=BAR
+# dotenv-linter:off LowercaseKey
+bar=FOO
+```

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -57,7 +57,7 @@ pub fn run(lines: &[LineEntry], skip_checks: &[&str]) -> Vec<Warning> {
     let mut warnings: Vec<Warning> = Vec::new();
 
     for line in lines {
-        if let Some(comment) = line.get_comment() {
+        if let Some(comment) = line.get_control_comment() {
             if comment.is_disabled() {
                 // Disable checks from a comment using the dotenv-linter:off flag
                 disabled_checks.extend(comment.checks);

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -57,21 +57,18 @@ pub fn run(lines: &[LineEntry], skip_checks: &[&str]) -> Vec<Warning> {
     let mut warnings: Vec<Warning> = Vec::new();
 
     for line in lines {
-        let is_comment = line.is_comment();
-        if is_comment {
-            if let Some(comment) = comment::parse(&line.raw_string) {
-                if comment.is_disabled() {
-                    // Disable checks from a comment using the dotenv-linter:off flag
-                    disabled_checks.extend(comment.checks);
-                } else {
-                    // Enable checks if the comment has the dotenv-linter:on flag
-                    disabled_checks.retain(|&s| !comment.checks.contains(&s));
-                }
+        if let Some(comment) = line.get_comment() {
+            if comment.is_disabled() {
+                // Disable checks from a comment using the dotenv-linter:off flag
+                disabled_checks.extend(comment.checks);
+            } else {
+                // Enable checks if the comment has the dotenv-linter:on flag
+                disabled_checks.retain(|&s| !comment.checks.contains(&s));
             }
         }
 
         for ch in &mut checks {
-            if is_comment && ch.skip_comments() {
+            if line.is_comment() && ch.skip_comments() {
                 continue;
             }
 

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -27,8 +27,8 @@ impl Default for UnorderedKeyChecker<'_> {
 
 impl Check for UnorderedKeyChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
-        // Support of grouping variables through blank lines
-        if line.is_empty() {
+        // Support of grouping variables through blank lines and control comments
+        if line.is_empty() || line.get_comment().is_some() {
             self.keys.clear();
             return None;
         }
@@ -184,6 +184,17 @@ mod tests {
             (line_entry(1, 3, "FOO=BAR"), None),
             (line_entry(2, 3, ""), None),
             (line_entry(3, 3, "BAR=FOO"), None),
+        ];
+
+        run_unordered_tests(asserts);
+    }
+
+    #[test]
+    fn one_unordered_key_with_control_comment_test() {
+        let asserts = vec![
+            (line_entry(1, 3, "FOO=BAR"), None),
+            (line_entry(2, 3, "# dotenv-linter:off LowercaseKey"), None),
+            (line_entry(3, 3, "bar=FOO"), None),
         ];
 
         run_unordered_tests(asserts);

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -28,7 +28,7 @@ impl Default for UnorderedKeyChecker<'_> {
 impl Check for UnorderedKeyChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         // Support of grouping variables through blank lines and control comments
-        if line.is_empty() || line.get_comment().is_some() {
+        if line.is_empty() || line.get_control_comment().is_some() {
             self.keys.clear();
             return None;
         }

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -8,8 +8,7 @@ pub struct LineEntry {
     pub raw_string: String,
 
     /// Used in ExtraBlankLineFixer
-    pub is_deleted: bool
-    // pub comment: Option<Comment<'a>>
+    pub is_deleted: bool,
 }
 
 impl LineEntry {
@@ -61,6 +60,7 @@ impl LineEntry {
 
     // Maybe we should add the comment field to the LineEntry struct (but this requires some
     // refactoring of the line entries creation)
+    // pub comment: Option<Comment<'a>>
     pub fn get_comment(&self) -> Option<Comment> {
         if !self.is_comment() {
             return None;

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -60,8 +60,8 @@ impl LineEntry {
 
     // Maybe we should add the comment field to the LineEntry struct (but this requires some
     // refactoring of the line entries creation)
-    // pub comment: Option<Comment<'a>>
-    pub fn get_comment(&self) -> Option<Comment> {
+    // pub control_comment: Option<Comment<'a>>
+    pub fn get_control_comment(&self) -> Option<Comment> {
         if !self.is_comment() {
             return None;
         }
@@ -208,16 +208,16 @@ mod tests {
         }
     }
 
-    mod get_comment {
+    mod get_control_comment {
         use super::*;
 
         #[test]
         fn line_with_control_comment_test() {
             let entry = line_entry(1, 1, "# dotenv-linter:off LowercaseKey");
-            let comment = entry.get_comment();
+            let comment = entry.get_control_comment();
             assert!(comment.is_some());
 
-            let comment = entry.get_comment().expect("comment");
+            let comment = entry.get_control_comment().expect("comment");
             assert_eq!(comment.is_disabled(), true);
             assert_eq!(comment.checks, vec!["LowercaseKey"]);
         }
@@ -225,7 +225,7 @@ mod tests {
         #[test]
         fn line_with_no_comment_test() {
             let entry = line_entry(1, 1, "A=B");
-            let comment = entry.get_comment();
+            let comment = entry.get_control_comment();
             assert!(comment.is_none());
         }
     }


### PR DESCRIPTION
I changed the `UnorderedKey` check's logic.

Now it also splits lines into sortable groups by control comments.

This is done to make the linter logic more predictable.

#### Before this PR:
File:
```
BB=1
# dotenv-linter:off LowercaseKey
Aa=B
X=X

```
There is one warning (line 3).

After fixing we expect something like this:
```
Aa=B
BB=1
# dotenv-linter:off LowercaseKey
X=X

```

And we will get the incorrect file after fixing.
If we fix the `Aa` key somehow, it will not be the best solution either, because a user obviously doesn't want fix the lower case.

#### After this PR:
File:
```
BB=1
# dotenv-linter:off LowercaseKey
Aa=B
X=X

```
There is no warnings.


#### ✔ Checklist:

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).
