### PR TITLE
Fix a bug with UnorderedKeyChecker and control comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
+- Fix a bug with `UnorderedKeyChecker` and control comments [#283](https://github.com/dotenv-linter/dotenv-linter/pull/283) ([@mgrachev](https://github.com/mgrachev))
 - Change the line grouping for the `UnorderedKey` checker [#281](https://github.com/dotenv-linter/dotenv-linter/pull/281) ([@evgeniy-r](https://github.com/evgeniy-r))
 - Fix a bug with `ExtraBlankLineFixer` and control comments [#279](https://github.com/dotenv-linter/dotenv-linter/pull/279) ([@mgrachev](https://github.com/mgrachev))
 - Move logic for creating `LineEntry` for tests to `common` module [#280](https://github.com/dotenv-linter/dotenv-linter/pull/280) ([@mgrachev](https://github.com/mgrachev))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -264,4 +264,22 @@ mod tests {
             assert!(available_check_names.contains(&check_name.to_string()));
         }
     }
+
+    #[test]
+    fn unordered_key_with_control_comment_test() {
+        let line_entries = vec![
+            line_entry(1, 7, "FOO=BAR"),
+            line_entry(2, 7, "# dotenv-linter:off LowercaseKey"),
+            line_entry(3, 7, "Bar=FOO"),
+            line_entry(4, 7, "bar=FOO"),
+            line_entry(5, 7, "# dotenv-linter:on LowercaseKey"),
+            line_entry(6, 7, "X=X"),
+            blank_line_entry(7, 7),
+        ];
+
+        let expected: Vec<Warning> = Vec::new();
+        let skip_checks: Vec<&str> = Vec::new();
+
+        assert_eq!(expected, run(&line_entries, &skip_checks));
+    }
 }

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -55,6 +55,10 @@ impl Check for UnorderedKeyChecker<'_> {
     fn name(&self) -> &str {
         self.name
     }
+
+    fn skip_comments(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -194,7 +198,7 @@ mod tests {
         let asserts = vec![
             (line_entry(1, 3, "FOO=BAR"), None),
             (line_entry(2, 3, "# dotenv-linter:off LowercaseKey"), None),
-            (line_entry(3, 3, "bar=FOO"), None),
+            (line_entry(3, 3, "Bar=FOO"), None),
         ];
 
         run_unordered_tests(asserts);


### PR DESCRIPTION
I have found a bug in this PR https://github.com/dotenv-linter/dotenv-linter/pull/281.

If we run `dotenv-linter` against this file:
```env
# .env
BB=1
# dotenv-linter:off LowercaseKey
Aa=B
X=X

```

We will get the warning:
```bash
$ dotenv-linter .env
.env:3 UnorderedKey: The Aa key should go before the BB key
```

@evgeniy-r Please take a look at it 👀

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
