### PR TITLE
Add check_output function for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add `check_output` helper function for integration tests [#305](https://github.com/dotenv-linter/dotenv-linter/pull/305) ([@Anthuang](https://github.com/anthuang))
 - Add action-misspell [#304](https://github.com/dotenv-linter/dotenv-linter/pull/304) ([@PurpleMyst](https://github.com/PurpleMyst))
 - Add action-shellcheck [#303](https://github.com/dotenv-linter/dotenv-linter/pull/303) ([@amd-9](https://github.com/amd-9))
 - Add fixer: UnorderedKeyFixer [#261](https://github.com/dotenv-linter/dotenv-linter/pull/261) ([@evgeniy-r](https://github.com/evgeniy-r))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Add `check_output` helper function for integration tests [#305](https://github.com/dotenv-linter/dotenv-linter/pull/305) ([@Anthuang](https://github.com/anthuang))
 - Add action-misspell [#304](https://github.com/dotenv-linter/dotenv-linter/pull/304) ([@PurpleMyst](https://github.com/PurpleMyst))
 - Add action-shellcheck [#303](https://github.com/dotenv-linter/dotenv-linter/pull/303) ([@amd-9](https://github.com/amd-9))
 - Add fixer: UnorderedKeyFixer [#261](https://github.com/dotenv-linter/dotenv-linter/pull/261) ([@evgeniy-r](https://github.com/evgeniy-r))
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
+- Add `check_output` helper function for integration tests [#305](https://github.com/dotenv-linter/dotenv-linter/pull/305) ([@Anthuang](https://github.com/anthuang))
 - Update args help [#299](https://github.com/dotenv-linter/dotenv-linter/pull/299) ([@mgrachev](https://github.com/mgrachev))
 - Move `remove_invalid_leading_chars_test` to `tests` module [#298](https://github.com/dotenv-linter/dotenv-linter/pull/298) ([@mgrachev](https://github.com/mgrachev))
 - Add command to install latest version via `Homebrew` [#297](https://github.com/dotenv-linter/dotenv-linter/pull/297) ([@mgrachev](https://github.com/mgrachev))

--- a/tests/checks/ending_blank_line.rs
+++ b/tests/checks/ending_blank_line.rs
@@ -1,4 +1,4 @@
-use crate::common::TestDir;
+use crate::common::*;
 
 #[test]
 fn correct_files() {
@@ -31,11 +31,11 @@ fn incorrect_files() {
         let testdir = TestDir::new();
         let testfile = testdir.create_testfile(".env", content);
         let args = &[testfile.as_str()];
-        let expected_output = format!(
-            "{}:{} EndingBlankLine: No blank line at the end of the file\n\nFound 1 problem\n",
-            testfile.shortname_as_str(),
+        let expected_output = check_output(&[format!(
+            ".env:{} EndingBlankLine: No blank line at the end of the file",
             expected_line_numbers[i]
-        );
+        )
+        .as_str()]);
 
         testdir.test_command_fail_with_args(args, expected_output);
     }

--- a/tests/checks/extra_blank_line.rs
+++ b/tests/checks/extra_blank_line.rs
@@ -1,4 +1,4 @@
-use crate::common::TestDir;
+use crate::common::*;
 
 #[test]
 fn correct_files() {
@@ -24,11 +24,7 @@ fn two_blank_lines_at_the_beginning() {
     let testdir = TestDir::new();
     let testfile = testdir.create_testfile(".env", content);
     let args = &[testfile.as_str()];
-    let expected_output = format!(
-        "{}:{} ExtraBlankLine: Extra blank line detected\n\nFound 1 problem\n",
-        testfile.shortname_as_str(),
-        2
-    );
+    let expected_output = check_output(&[".env:2 ExtraBlankLine: Extra blank line detected"]);
 
     testdir.test_command_fail_with_args(args, expected_output);
 }
@@ -40,11 +36,7 @@ fn two_blank_lines_in_the_middle() {
     let testdir = TestDir::new();
     let testfile = testdir.create_testfile(".env", content);
     let args = &[testfile.as_str()];
-    let expected_output = format!(
-        "{}:{} ExtraBlankLine: Extra blank line detected\n\nFound 1 problem\n",
-        testfile.shortname_as_str(),
-        4
-    );
+    let expected_output = check_output(&[".env:4 ExtraBlankLine: Extra blank line detected"]);
 
     testdir.test_command_fail_with_args(args, expected_output);
 }
@@ -56,11 +48,7 @@ fn two_blank_lines_at_the_end() {
     let testdir = TestDir::new();
     let testfile = testdir.create_testfile(".env", content);
     let args = &[testfile.as_str()];
-    let expected_output = format!(
-        "{}:{} ExtraBlankLine: Extra blank line detected\n\nFound 1 problem\n",
-        testfile.shortname_as_str(),
-        5
-    );
+    let expected_output = check_output(&[".env:5 ExtraBlankLine: Extra blank line detected"]);
 
     testdir.test_command_fail_with_args(args, expected_output);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,5 +2,5 @@ mod output;
 mod test_dir;
 mod test_file;
 
-pub use output::fix_output;
+pub use output::*;
 pub use test_dir::TestDir;

--- a/tests/common/output.rs
+++ b/tests/common/output.rs
@@ -3,5 +3,11 @@ const FIX_SENTENCE: &str = "All warnings are fixed. Total:";
 pub fn fix_output(warnings: &[&str]) -> String {
     let total = warnings.len();
     let output: &str = &warnings.join("\n");
-    String::from(format!("{}\n\n{} {}\n", output, FIX_SENTENCE, total))
+    format!("{}\n\n{} {}\n", output, FIX_SENTENCE, total)
+}
+
+pub fn check_output(warnings: &[&str]) -> String {
+    let total = warnings.len();
+    let output: &str = &warnings.join("\n");
+    format!("{}\n\nFound {} problem\n", output, total)
 }


### PR DESCRIPTION
This PR adds a `check_output` function for integration tests, and refactors current tests to use it. The added function is made to be similar to `fix_output`, which already exists.

Resolves: #293

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

~- [ ] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);~
~- [ ] Tests for the changes have been added (for bug fixes / features);~
~- [ ] Docs have been added / updated (for bug fixes / features).~

Crossed out the above since this is just an internal improvement. Let me know if there's anything else I should do!

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
