### PR TITLE
Remove unused variable `CARGO_TERM_COLOR` in shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,9 +1,6 @@
 name: shellcheck
 on: [pull_request]
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   shellcheck:
     name: Check / shellcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
+- Remove `CARGO_TERM_COLOR` from the shellcheck workflow [#313](https://github.com/dotenv-linter/dotenv-linter/pull/313)
 - Add `check_output` helper function for integration tests [#305](https://github.com/dotenv-linter/dotenv-linter/pull/305) ([@Anthuang](https://github.com/anthuang))
 - Add an additional test for `LineEntry.get_value` [#306](https://github.com/dotenv-linter/dotenv-linter/pull/306) ([@vvkpd](https://github.com/vvkpd))
 - Update args help [#299](https://github.com/dotenv-linter/dotenv-linter/pull/299) ([@mgrachev](https://github.com/mgrachev))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add installation CI test for Windows (via `install.sh`) [#235](https://github.com/dotenv-linter/dotenv-linter/pull/235) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
-- Remove `CARGO_TERM_COLOR` from the shellcheck workflow [#313](https://github.com/dotenv-linter/dotenv-linter/pull/313)
+- Remove `CARGO_TERM_COLOR` from the shellcheck workflow [#313](https://github.com/dotenv-linter/dotenv-linter/pull/313) ([@MusiKid](https://github.com/MusiKid))
 - Add `check_output` helper function for integration tests [#305](https://github.com/dotenv-linter/dotenv-linter/pull/305) ([@Anthuang](https://github.com/anthuang))
 - Add an additional test for `LineEntry.get_value` [#306](https://github.com/dotenv-linter/dotenv-linter/pull/306) ([@vvkpd](https://github.com/vvkpd))
 - Update args help [#299](https://github.com/dotenv-linter/dotenv-linter/pull/299) ([@mgrachev](https://github.com/mgrachev))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
This PR removes the ununsed environment variable **$CARGO_TERM_COLOR** in the shellcheck GitHub workflow.
<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
