### PR TITLE
Fix docker release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Fix docker release [#319](https://github.com/dotenv-linter/dotenv-linter/pull/319) ([@mgrachev](https://github.com/mgrachev))
 
 ## [v2.2.0] - 2020-10-12
 ### 🚀 Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42 as builder
+FROM rust:latest as builder
 WORKDIR /usr/src
 RUN rustup target add x86_64-unknown-linux-musl
 


### PR DESCRIPTION
```rust
error[E0658]: use of unstable library feature 'str_strip': newly added
  --> src/common/comment.rs:17:10
   |
17 |         .strip_prefix(format!("{}:", PREFIX).as_str())?
   |          ^^^^^^^^^^^^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/67302

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.
error: could not compile `dotenv-linter`.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `dotenv-linter v2.2.0 (/usr/src/dotenv-linter)`, intermediate artifacts can be found at `/usr/src/dotenv-linter/target`
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
