### PR TITLE
Add default exclude list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### 🚀 Added
 - Add action-yamllint [#317](https://github.com/dotenv-linter/dotenv-linter/pull/317) ([@vk26](https://github.com/vk26))
-- Add exclude list [#324](https://github.com/dotenv-linter/dotenv-linter/pull/324) ([@ametalon](https://github.com/ametalon))
+- Add default exclude list [#324](https://github.com/dotenv-linter/dotenv-linter/pull/324) ([@ametalon](https://github.com/ametalon))
 
 ### 🔧 Changed
 - Added docker build step to the CI pipeline [#322](https://github.com/dotenv-linter/dotenv-linter/pull/322) ([@JoeAmedeo](https://github.com/JoeAmedeo))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### 🚀 Added
 - Add action-yamllint [#317](https://github.com/dotenv-linter/dotenv-linter/pull/317) ([@vk26](https://github.com/vk26))
+- Add exclude list [#324](https://github.com/dotenv-linter/dotenv-linter/pull/324) ([@ametalon](https://github.com/ametalon))
 
 ### 🔧 Changed
 - Added docker build step to the CI pipeline [#322](https://github.com/dotenv-linter/dotenv-linter/pull/322) ([@JoeAmedeo](https://github.com/JoeAmedeo))

--- a/src/common/file_entry.rs
+++ b/src/common/file_entry.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use crate::common::*;
 
+const EXCLUDED_FILES: &[&str] = &[".envrc"];
+
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct FileEntry {
     pub path: PathBuf,
@@ -51,6 +53,7 @@ impl FileEntry {
     pub fn is_env_file(path: &PathBuf) -> bool {
         let pattern = ".env";
         Self::get_file_name(path)
+            .filter(|file_name| !EXCLUDED_FILES.contains(&file_name.as_str()))
             .filter(|file_name| file_name.starts_with(pattern) || file_name.ends_with(pattern))
             .is_some()
     }
@@ -101,7 +104,7 @@ mod tests {
 
     #[test]
     fn is_env_file_test() {
-        let assertions = vec![
+        let mut assertions = vec![
             (".env", true),
             ("foo.env", true),
             (".env.foo", true),
@@ -113,6 +116,8 @@ mod tests {
             (".my-env-file", false),
             ("dev.env.js", false),
         ];
+
+        assertions.extend(EXCLUDED_FILES.iter().map(|file| (*file, false)));
 
         for (file_name, expected) in assertions {
             assert_eq!(


### PR DESCRIPTION
First stab at #323
This implementation hard-excludes files and there is no way to run checks on them.
Even running the linter with these files listed explicitly will still skip them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
