### PR TITLE
Remade flags to subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add export prefix support [#340](https://github.com/dotenv-linter/dotenv-linter/pull/340)([@skonik](https://github.com/skonik))
 
 ### 🔧 Changed
+- Remade flags to subcommands [#342](https://github.com/dotenv-linter/dotenv-linter/pull/342) ([@mgrachev](https://github.com/mgrachev))
 - Changed behavior of QuoteCharacterChecker for multiline values support [#341](https://github.com/dotenv-linter/dotenv-linter/pull/341) ([@artem-russkikh](http://github.com/artem-russkikh))
 - Make an output on-the-fly [#336](https://github.com/dotenv-linter/dotenv-linter/pull/336) ([@DDtKey](https://github.com/DDtKey))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["environment", "env", "dotenv", "linter", "lint"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = "2.33.0"
+clap = "2.33.3"
 colored = "2.0.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/common/output/check.rs
+++ b/src/common/output/check.rs
@@ -18,14 +18,19 @@ impl CheckOutput {
 
     /// Prints information about a file in process
     pub fn print_processing_info(&self, file: &FileEntry) {
-        if !&self.is_quiet_mode {
+        if !self.is_quiet_mode {
             println!("Checking {}", file);
         }
     }
 
-    /// Prints warnings without any additional information.
+    /// Prints warnings without any additional information
     pub fn print_warnings(&self, warnings: &[Warning], file_index: usize) {
         warnings.iter().for_each(|w| println!("{}", w));
+
+        if self.is_quiet_mode {
+            return;
+        }
+
         let is_last_file = file_index == self.files_count - 1;
         if !warnings.is_empty() && !is_last_file {
             println!();

--- a/src/common/output/fix.rs
+++ b/src/common/output/fix.rs
@@ -1,22 +1,27 @@
-use crate::common::FileEntry;
+use crate::common::{FileEntry, Warning};
 use std::ffi::OsString;
 
-/// Prefix for the backup output.
+/// Prefix for the backup output
 const BACKUP_PREFIX: &str = "Original file was backed up to: ";
 
 pub struct FixOutput {
     // Quiet program output mode
     is_quiet_mode: bool,
+    // Total number of files to check
+    files_count: usize,
 }
 
 impl FixOutput {
-    pub fn new(is_quiet_mode: bool) -> Self {
-        FixOutput { is_quiet_mode }
+    pub fn new(is_quiet_mode: bool, files_count: usize) -> Self {
+        FixOutput {
+            is_quiet_mode,
+            files_count,
+        }
     }
 
     /// Prints information about a file in process
     pub fn print_processing_info(&self, file: &FileEntry) {
-        if !&self.is_quiet_mode {
+        if !self.is_quiet_mode {
             println!("Fixing {}", file);
         }
     }
@@ -29,10 +34,23 @@ impl FixOutput {
         }
     }
 
-    /// Prints the backup file's path.
+    /// Prints the backup file's path
     pub fn print_backup(&self, backup_path: &OsString) {
         println!("{}{:?}", BACKUP_PREFIX, backup_path);
         if !self.is_quiet_mode {
+            println!();
+        }
+    }
+
+    /// Prints warnings without any additional information
+    pub fn print_warnings(&self, warnings: &[Warning], file_index: usize) {
+        if self.is_quiet_mode {
+            return;
+        }
+
+        warnings.iter().for_each(|w| println!("{}", w));
+        let is_last_file = file_index == self.files_count - 1;
+        if !warnings.is_empty() && !is_last_file {
             println!();
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,41 @@
-use clap::Arg;
+use clap::{AppSettings, Arg, SubCommand};
 use std::error::Error;
 use std::ffi::OsStr;
 use std::{env, process};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(windows)]
+    colored::control::set_virtual_terminal(true).ok();
+
     let current_dir = env::current_dir()?;
     let args = get_args(current_dir.as_os_str());
 
-    if args.is_present("show-checks") {
-        dotenv_linter::available_check_names()
-            .iter()
-            .for_each(|name| println!("{}", name));
-        process::exit(0);
-    }
-
-    let no_color = args.is_present("no-color");
-    if no_color {
+    if args.is_present("no-color") {
         colored::control::set_override(false);
     }
-    #[cfg(windows)]
-    set_windows_virtual_terminal();
 
-    let total_warnings = dotenv_linter::run(&args, &current_dir)?;
+    match args.subcommand() {
+        ("", None) => {
+            let total_warnings = dotenv_linter::check(&args, &current_dir)?;
 
-    // Ensure the exit code is 0 if there are no warnings or have been fixed.
-    if args.is_present("fix") || total_warnings == 0 {
-        process::exit(0);
+            if total_warnings == 0 {
+                process::exit(0);
+            }
+        }
+        ("fix", Some(fix_args)) => {
+            dotenv_linter::fix(&fix_args, &current_dir)?;
+            process::exit(0);
+        }
+        ("list", Some(_)) => {
+            dotenv_linter::available_check_names()
+                .iter()
+                .for_each(|name| println!("{}", name));
+
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown command");
+        }
     }
 
     process::exit(1);
@@ -33,73 +43,69 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
     clap::App::new(env!("CARGO_PKG_NAME"))
+        .setting(AppSettings::ColoredHelp)
+        .setting(AppSettings::DisableHelpSubcommand)
+        .setting(AppSettings::VersionlessSubcommands)
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .version(env!("CARGO_PKG_VERSION"))
         .version_short("v")
-        .arg(
-            Arg::with_name("input")
-                .help("files or paths")
-                .index(1)
-                .default_value_os(current_dir)
-                .required(true)
-                .multiple(true),
+        .args(common_args(current_dir).as_ref())
+        .subcommand(
+            SubCommand::with_name("list")
+                .setting(AppSettings::ColoredHelp)
+                .visible_alias("l")
+                .usage("dotenv-linter list")
+                .about("Shows list of available checks"),
         )
-        .arg(
-            Arg::with_name("exclude")
-                .short("e")
-                .long("exclude")
-                .value_name("FILE_NAME")
-                .help("Excludes files from check")
-                .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("skip")
-                .short("s")
-                .long("skip")
-                .value_name("CHECK_NAME")
-                .help("Skips checks")
-                .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("show-checks")
-                .long("show-checks")
-                .help("Shows list of available checks"),
-        )
-        .arg(
-            Arg::with_name("recursive")
-                .short("r")
-                .long("recursive")
-                .help("Recursively search and check .env files"),
-        )
-        .arg(
-            Arg::with_name("no-color")
-                .long("no-color")
-                .help("Turns off the colored output"),
-        )
-        .arg(
-            Arg::with_name("fix")
-                .short("f")
-                .long("fix")
-                .help("Automatically fixes warnings"),
-        )
-        .arg(
-            Arg::with_name("no-backup")
-                .long("no-backup")
-                .help("Prevents .env files from being backed up when modified by -f/--fix"),
-        )
-        .arg(
-            Arg::with_name("quiet")
-                .short("q")
-                .long("quiet")
-                .help("Doesn't display additional information"),
+        .subcommand(
+            SubCommand::with_name("fix")
+                .setting(AppSettings::ColoredHelp)
+                .visible_alias("f")
+                .args(common_args(current_dir).as_ref())
+                .arg(
+                    Arg::with_name("no-backup")
+                        .long("no-backup")
+                        .help("Prevents backing up .env files"),
+                )
+                .usage("dotenv-linter fix [FLAGS] [OPTIONS] <input>...")
+                .about("Automatically fixes warnings"),
         )
         .get_matches()
 }
 
-#[cfg(windows)]
-pub fn set_windows_virtual_terminal() {
-    colored::control::set_virtual_terminal(true).ok();
+fn common_args(current_dir: &OsStr) -> Vec<Arg> {
+    vec![
+        Arg::with_name("input")
+            .help("files or paths")
+            .index(1)
+            .default_value_os(current_dir)
+            .required(true)
+            .multiple(true),
+        Arg::with_name("exclude")
+            .short("e")
+            .long("exclude")
+            .value_name("FILE_NAME")
+            .help("Excludes files from check")
+            .multiple(true)
+            .takes_value(true),
+        Arg::with_name("skip")
+            .short("s")
+            .long("skip")
+            .value_name("CHECK_NAME")
+            .help("Skips checks")
+            .multiple(true)
+            .takes_value(true),
+        Arg::with_name("recursive")
+            .short("r")
+            .long("recursive")
+            .help("Recursively searches and checks .env files"),
+        Arg::with_name("no-color")
+            .long("no-color")
+            .help("Turns off the colored output"),
+        Arg::with_name("quiet")
+            .short("q")
+            .long("quiet")
+            .help("Doesn't display additional information"),
+    ]
 }

--- a/tests/common/test_dir.rs
+++ b/tests/common/test_dir.rs
@@ -130,7 +130,7 @@ impl TestDir {
         let mut cmd = Self::init_cmd();
         let canonical_current_dir = canonicalize(&self.current_dir).expect("canonical current dir");
         cmd.current_dir(&canonical_current_dir)
-            .args(&["-f", "--no-backup"])
+            .args(&["fix", "--no-backup"])
             .assert()
             .success()
             .stdout(expected_output);
@@ -143,7 +143,7 @@ impl TestDir {
         let mut cmd = Self::init_cmd();
         let canonical_current_dir = canonicalize(&self.current_dir).expect("canonical current dir");
         cmd.current_dir(&canonical_current_dir)
-            .args(&["-f", "--no-backup"])
+            .args(&["fix", "--no-backup"])
             .assert()
             .success();
     }
@@ -160,7 +160,7 @@ impl TestDir {
         let mut cmd = Self::init_cmd();
         let canonical_current_dir = canonicalize(&self.current_dir).expect("canonical current dir");
         cmd.current_dir(&canonical_current_dir)
-            .args(&["-f", "--no-backup"])
+            .args(&["fix", "--no-backup"])
             .args(ext_args)
             .assert()
             .success()

--- a/tests/flags/backup.rs
+++ b/tests/flags/backup.rs
@@ -7,7 +7,7 @@ fn output_backup_file() {
     let testdir = TestDir::new();
     let content = "foo=bar\n";
     let testfile = testdir.create_testfile(".env", content);
-    let args = &[testfile.as_str(), "-f"];
+    let args = &[testfile.as_str(), "fix"];
 
     testdir.test_command_success_with_args_without_closing(args);
 

--- a/tests/flags/quiet.rs
+++ b/tests/flags/quiet.rs
@@ -15,6 +15,22 @@ fn check_output_in_quiet_mode() {
 }
 
 #[test]
+fn check_output_for_multiple_files_in_quiet_mode() {
+    let test_dir = TestDir::new();
+    let testfile_1 = test_dir.create_testfile(".env", "BAR='Baz'\n");
+    let testfile_2 = test_dir.create_testfile(".env2", " BAR=\n");
+
+    let args = &["--quiet"];
+    let expected_output = format!(
+        "{a}:1 QuoteCharacter: The value has quote characters (\', \")\n{b}:1 LeadingCharacter: Invalid leading character detected\n",
+        a=testfile_1.shortname_as_str(),
+        b=testfile_2.shortname_as_str()
+    );
+
+    test_dir.test_command_fail_with_args(args, expected_output);
+}
+
+#[test]
 fn fix_output_in_quiet_mode() {
     let test_dir = TestDir::new();
     let _ = test_dir.create_testfile(".env", "abc=DEF\n\nF=BAR\nB=bbb\n");

--- a/tests/output/fix.rs
+++ b/tests/output/fix.rs
@@ -176,7 +176,7 @@ fn backup() {
     let test_dir = TestDir::new();
     let test_file = test_dir.create_testfile(".env", "abc=DEF\n\nF=BAR\nB=bbb\n");
 
-    let args = &["-f"];
+    let args = &["fix"];
     let output = test_dir.test_command_success_and_get_output(args);
 
     let backup_file = fs::read_dir(&test_dir.as_str())
@@ -210,7 +210,7 @@ fn quiet_backup() {
     let test_dir = TestDir::new();
     let test_file = test_dir.create_testfile(".env", "abc=DEF\n\nF=BAR\nB=bbb\n");
 
-    let args = &["-f", "-q"];
+    let args = &["fix", "-q"];
     let output = test_dir.test_command_success_and_get_output(args);
 
     let backup_file = fs::read_dir(&test_dir.as_str())


### PR DESCRIPTION
Close #333 

What was done:
- [x] Remade the `--fix/-f` flag to the `fix` subcommand;
- [x] Remade the `--show-checks` flag to the `list` subcommand;
- [x] Fixed a bug with output for multiple files in quiet mode (and wrote a test for that case);
- [x] Added colored help output.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
