### PR TITLE
Remove unnecessary allocations and clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Refactoring to get rid of unnecessary heap allocations and some improvements in API ergonomics [#350](https://github.com/dotenv-linter/dotenv-linter/pull/350) ([@vbrandl](https://github.com/vbrandl))
 - Add colored output feature and `--no-color` flag to disable colors [#307](https://github.com/dotenv-linter/dotenv-linter/pull/307) ([@Nikhil0487](https://github.com/Nikhil0487))
 - Display linted files when run [#311](https://github.com/dotenv-linter/dotenv-linter/pull/311) ([@Anthuang](https://github.com/anthuang))
 - Add export prefix support [#340](https://github.com/dotenv-linter/dotenv-linter/pull/340)([@skonik](https://github.com/skonik))
 
 ### 🔧 Changed
+- Refactoring to get rid of unnecessary heap allocations and some improvements in API ergonomics [#350](https://github.com/dotenv-linter/dotenv-linter/pull/350) ([@vbrandl](https://github.com/vbrandl))
 - Add benchmark to README [#351](https://github.com/dotenv-linter/dotenv-linter/pull/351) ([@mgrachev](https://github.com/mgrachev))
 - Fix QuoteCharacterChecker to not raise warning when quote characters are used for values with whitespaces [#349](https://github.com/dotenv-linter/dotenv-linter/pull/349) ([@sebastiantoh](https://github.com/sebastiantoh))
 - Find all problems on the first run for `KeyWithoutValue` [#348](https://github.com/dotenv-linter/dotenv-linter/pull/348) ([@vbrandl](https://github.com/vbrandl))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Refactoring to get rid of unnecessary heap allocations and some improvements in API ergonomics [#350](https://github.com/dotenv-linter/dotenv-linter/pull/350) ([@vbrandl](https://github.com/vbrandl))
 - Add colored output feature and `--no-color` flag to disable colors [#307](https://github.com/dotenv-linter/dotenv-linter/pull/307) ([@Nikhil0487](https://github.com/Nikhil0487))
 - Display linted files when run [#311](https://github.com/dotenv-linter/dotenv-linter/pull/311) ([@Anthuang](https://github.com/anthuang))
 - Add export prefix support [#340](https://github.com/dotenv-linter/dotenv-linter/pull/340)([@skonik](https://github.com/skonik))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -135,7 +135,7 @@ mod tests {
         let warning = Warning::new(
             line.clone(),
             "KeyWithoutValue",
-            String::from("The FOO key should be with a value or have an equal sign"),
+            "The FOO key should be with a value or have an equal sign",
         );
         let lines: Vec<LineEntry> = vec![line, blank_line_entry(2, 2)];
         let expected: Vec<Warning> = vec![warning];
@@ -150,7 +150,7 @@ mod tests {
         let warning = Warning::new(
             line.clone(),
             "EndingBlankLine",
-            String::from("No blank line at the end of the file"),
+            "No blank line at the end of the file",
         );
         let lines: Vec<LineEntry> = vec![line];
         let expected: Vec<Warning> = vec![warning];
@@ -166,7 +166,7 @@ mod tests {
         let warning = Warning::new(
             line2.clone(),
             "LeadingCharacter",
-            String::from("Invalid leading character detected"),
+            "Invalid leading character detected",
         );
         let lines: Vec<LineEntry> = vec![line1, line2, blank_line_entry(3, 3)];
         let expected: Vec<Warning> = vec![warning];
@@ -193,7 +193,7 @@ mod tests {
         let warning = Warning::new(
             line3.clone(),
             "LeadingCharacter",
-            String::from("Invalid leading character detected"),
+            "Invalid leading character detected",
         );
         let lines: Vec<LineEntry> = vec![line1, line2, line3, blank_line_entry(4, 4)];
         let expected: Vec<Warning> = vec![warning];
@@ -210,7 +210,7 @@ mod tests {
         let warning = Warning::new(
             line3.clone(),
             "LeadingCharacter",
-            String::from("Invalid leading character detected"),
+            "Invalid leading character detected",
         );
         let lines: Vec<LineEntry> = vec![line1, line2, line3, blank_line_entry(4, 4)];
         let expected: Vec<Warning> = vec![warning];
@@ -232,7 +232,7 @@ mod tests {
         let warning = Warning::new(
             line4.clone(),
             "LeadingCharacter",
-            String::from("Invalid leading character detected"),
+            "Invalid leading character detected",
         );
         let lines: Vec<LineEntry> = vec![line1, line2, line3, line4, blank_line_entry(5, 5)];
         let expected: Vec<Warning> = vec![warning];
@@ -247,7 +247,7 @@ mod tests {
         let warning = Warning::new(
             line.clone(),
             "EndingBlankLine",
-            String::from("No blank line at the end of the file"),
+            "No blank line at the end of the file",
         );
         let lines: Vec<LineEntry> = vec![line];
         let expected: Vec<Warning> = vec![warning];

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -261,7 +261,9 @@ mod tests {
         let available_check_names = available_check_names();
         for check in checklist() {
             let check_name = check.name();
-            assert!(available_check_names.contains(&check_name.to_string()));
+            assert!(available_check_names
+                .iter()
+                .any(|name| name.as_str() == check_name));
         }
     }
 

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -64,7 +64,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 2, "FOO=BAR"),
                     "DuplicatedKey",
-                    String::from("The FOO key is duplicated"),
+                    "The FOO key is duplicated",
                 )),
             ),
         ];
@@ -100,7 +100,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 4, "FOO=BAR"),
                     "DuplicatedKey",
-                    String::from("The FOO key is duplicated"),
+                    "The FOO key is duplicated",
                 )),
             ),
             (line_entry(3, 4, "BAR=FOO"), None),
@@ -109,7 +109,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(4, 4, "BAR=FOO"),
                     "DuplicatedKey",
-                    String::from("The BAR key is duplicated"),
+                    "The BAR key is duplicated",
                 )),
             ),
         ];
@@ -126,7 +126,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 3, "FOO=BAR"),
                     "DuplicatedKey",
-                    String::from("The FOO key is duplicated"),
+                    "The FOO key is duplicated",
                 )),
             ),
             (line_entry(3, 3, "BAR=FOO"), None),

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -66,7 +66,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "EndingBlankLine",
-            String::from("No blank line at the end of the file"),
+            "No blank line at the end of the file",
         ));
 
         assert_eq!(expected, checker.run(&line));

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -16,8 +16,8 @@ impl Default for EndingBlankLineChecker<'_> {
 }
 
 impl EndingBlankLineChecker<'_> {
-    fn message(&self) -> String {
-        String::from(self.template)
+    fn message(&self) -> &str {
+        self.template
     }
 }
 

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -8,8 +8,8 @@ pub(crate) struct ExtraBlankLineChecker<'a> {
 }
 
 impl ExtraBlankLineChecker<'_> {
-    fn message(&self) -> String {
-        String::from(self.template)
+    fn message(&self) -> &str {
+        self.template
     }
 }
 

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -59,8 +59,7 @@ mod tests {
             let (content, message) = *assert;
             let line = line_entry(i + 1, asserts.len(), content);
 
-            let expected =
-                message.map(|msg| Warning::new(line.clone(), "ExtraBlankLine", String::from(msg)));
+            let expected = message.map(|msg| Warning::new(line.clone(), "ExtraBlankLine", msg));
 
             assert_eq!(checker.run(&line), expected);
         }

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -87,7 +87,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "IncorrectDelimiter",
-            String::from("The ***F-OOBAR key has incorrect delimiter"),
+            "The ***F-OOBAR key has incorrect delimiter",
         ));
 
         assert_eq!(expected, checker.run(&line));
@@ -101,7 +101,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "IncorrectDelimiter",
-            String::from("The FOO* key has incorrect delimiter"),
+            "The FOO* key has incorrect delimiter",
         ));
 
         assert_eq!(expected, checker.run(&line));
@@ -114,7 +114,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "IncorrectDelimiter",
-            String::from("The FOO-BAR key has incorrect delimiter"),
+            "The FOO-BAR key has incorrect delimiter",
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -126,7 +126,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "IncorrectDelimiter",
-            String::from("The FOO BAR key has incorrect delimiter"),
+            "The FOO BAR key has incorrect delimiter",
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -138,7 +138,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "IncorrectDelimiter",
-            String::from("The FOO-BAR key has incorrect delimiter"),
+            "The FOO-BAR key has incorrect delimiter",
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -72,7 +72,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "KeyWithoutValue",
-            String::from("The FOO key should be with a value or have an equal sign"),
+            "The FOO key should be with a value or have an equal sign",
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -72,11 +72,7 @@ mod tests {
         let mut checker = LeadingCharacterChecker::default();
         let line = line_entry(1, 1, ".FOO=BAR");
         assert_eq!(
-            Some(Warning::new(
-                line.clone(),
-                "LeadingCharacter",
-                MESSAGE.to_string()
-            )),
+            Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE)),
             checker.run(&line)
         );
     }
@@ -86,11 +82,7 @@ mod tests {
         let mut checker = LeadingCharacterChecker::default();
         let line = line_entry(1, 1, "*FOO=BAR");
         assert_eq!(
-            Some(Warning::new(
-                line.clone(),
-                "LeadingCharacter",
-                MESSAGE.to_string()
-            )),
+            Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE)),
             checker.run(&line)
         );
     }
@@ -100,11 +92,7 @@ mod tests {
         let mut checker = LeadingCharacterChecker::default();
         let line = line_entry(1, 1, "1FOO=BAR");
         assert_eq!(
-            Some(Warning::new(
-                line.clone(),
-                "LeadingCharacter",
-                MESSAGE.to_string()
-            )),
+            Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE)),
             checker.run(&line)
         );
     }
@@ -113,11 +101,7 @@ mod tests {
     fn leading_space() {
         let mut checker = LeadingCharacterChecker::default();
         let line = line_entry(1, 1, " FOO=BAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "LeadingCharacter",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -125,11 +109,7 @@ mod tests {
     fn two_leading_spaces() {
         let mut checker = LeadingCharacterChecker::default();
         let line = line_entry(1, 1, "  FOO=BAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "LeadingCharacter",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -137,11 +117,7 @@ mod tests {
     fn leading_tab() {
         let mut checker = LeadingCharacterChecker::default();
         let line = line_entry(1, 1, "\tFOO=BAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "LeadingCharacter",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -16,8 +16,8 @@ impl Default for LeadingCharacterChecker<'_> {
 }
 
 impl LeadingCharacterChecker<'_> {
-    fn message(&self) -> String {
-        String::from(self.template)
+    fn message(&self) -> &str {
+        self.template
     }
 }
 

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -62,7 +62,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "LowercaseKey",
-            String::from("The foo_bar key should be in uppercase"),
+            "The foo_bar key should be in uppercase",
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -74,7 +74,7 @@ mod tests {
         let expected = Some(Warning::new(
             line.clone(),
             "LowercaseKey",
-            String::from("The FOo_BAR key should be in uppercase"),
+            "The FOo_BAR key should be in uppercase",
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -7,8 +7,8 @@ pub(crate) struct QuoteCharacterChecker<'a> {
 }
 
 impl QuoteCharacterChecker<'_> {
-    fn message(&self) -> String {
-        String::from(self.template)
+    fn message(&self) -> &str {
+        self.template
     }
 }
 

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -63,7 +63,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 3, "FOO='BAR'"),
                     "QuoteCharacter",
-                    String::from("The value has quote characters (\', \")"),
+                    "The value has quote characters (\', \")",
                 )),
             ),
             (
@@ -71,7 +71,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(3, 3, "FOO='B\"AR'"),
                     "QuoteCharacter",
-                    String::from("The value has quote characters (\', \")"),
+                    "The value has quote characters (\', \")",
                 )),
             ),
         ];
@@ -88,7 +88,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 2, "FOO=\"BAR\""),
                     "QuoteCharacter",
-                    String::from("The value has quote characters (\', \")"),
+                    "The value has quote characters (\', \")",
                 )),
             ),
         ];

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -85,11 +85,7 @@ mod tests {
     fn failing_run() {
         let mut checker = SpaceCharacterChecker::default();
         let line = line_entry(1, 1, "DEBUG-HTTP = true");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "SpaceCharacter",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "SpaceCharacter", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -97,11 +93,7 @@ mod tests {
     fn failing_when_whitespace_before_equal_sign_run() {
         let mut checker = SpaceCharacterChecker::default();
         let line = line_entry(1, 1, "DEBUG-HTTP =true");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "SpaceCharacter",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "SpaceCharacter", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -109,11 +101,7 @@ mod tests {
     fn failing_when_whitespace_after_equal_sign_run() {
         let mut checker = SpaceCharacterChecker::default();
         let line = line_entry(1, 1, "DEBUG-HTTP= true");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "SpaceCharacter",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "SpaceCharacter", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -7,8 +7,8 @@ pub(crate) struct SpaceCharacterChecker<'a> {
 }
 
 impl SpaceCharacterChecker<'_> {
-    fn message(&self) -> String {
-        String::from(self.template)
+    fn message(&self) -> &str {
+        self.template
     }
 }
 

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -55,11 +55,7 @@ mod tests {
     fn failing_trailing_run() {
         let mut checker = TrailingWhitespaceChecker::default();
         let line = line_entry(1, 1, "DEBUG_HTTP=true  ");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "TrailingWhitespace",
-            MESSAGE.to_string(),
-        ));
+        let expected = Some(Warning::new(line.clone(), "TrailingWhitespace", MESSAGE));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -7,8 +7,8 @@ pub(crate) struct TrailingWhitespaceChecker<'a> {
 }
 
 impl TrailingWhitespaceChecker<'_> {
-    fn message(&self) -> String {
-        String::from(self.template)
+    fn message(&self) -> &str {
+        self.template
     }
 }
 

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -98,7 +98,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 2, "BAR=FOO"),
                     "UnorderedKey",
-                    String::from("The BAR key should go before the FOO key"),
+                    "The BAR key should go before the FOO key",
                 )),
             ),
         ];
@@ -115,7 +115,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 3, "BAR=FOO"),
                     "UnorderedKey",
-                    String::from("The BAR key should go before the FOO key"),
+                    "The BAR key should go before the FOO key",
                 )),
             ),
             (
@@ -123,7 +123,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(3, 3, "ABC=BAR"),
                     "UnorderedKey",
-                    String::from("The ABC key should go before the BAR key"),
+                    "The ABC key should go before the BAR key",
                 )),
             ),
         ];
@@ -140,7 +140,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 3, "BAR=FOO"),
                     "UnorderedKey",
-                    String::from("The BAR key should go before the FOO key"),
+                    "The BAR key should go before the FOO key",
                 )),
             ),
             (
@@ -148,7 +148,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(3, 3, "DDD=BAR"),
                     "UnorderedKey",
-                    String::from("The DDD key should go before the FOO key"),
+                    "The DDD key should go before the FOO key",
                 )),
             ),
         ];
@@ -165,7 +165,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(2, 4, "BAR=FOO"),
                     "UnorderedKey",
-                    String::from("The BAR key should go before the FOO key"),
+                    "The BAR key should go before the FOO key",
                 )),
             ),
             (
@@ -173,7 +173,7 @@ mod tests {
                 Some(Warning::new(
                     line_entry(3, 4, "DDD=BAR"),
                     "UnorderedKey",
-                    String::from("The DDD key should go before the FOO key"),
+                    "The DDD key should go before the FOO key",
                 )),
             ),
             (line_entry(4, 4, "ZOO=BAR"), None),

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,11 +13,8 @@ pub use warning::Warning;
 
 pub const LF: &str = "\n";
 
-pub fn remove_invalid_leading_chars(string: &str) -> String {
-    string
-        .chars()
-        .skip_while(|&c| !(c.is_alphabetic() || c == '_'))
-        .collect()
+pub fn remove_invalid_leading_chars(string: &str) -> &str {
+    string.trim_start_matches(|c: char| !(c.is_alphabetic() || c == '_'))
 }
 
 pub(crate) mod tests {
@@ -54,10 +51,10 @@ pub(crate) mod tests {
 
     #[test]
     fn remove_invalid_leading_chars_test() {
-        let string = String::from("-1&*FOO");
-        assert_eq!("FOO", remove_invalid_leading_chars(&string));
+        let string = "-1&*FOO";
+        assert_eq!("FOO", remove_invalid_leading_chars(string));
 
-        let string = String::from("***FOO-BAR");
-        assert_eq!("FOO-BAR", remove_invalid_leading_chars(&string));
+        let string = "***FOO-BAR";
+        assert_eq!("FOO-BAR", remove_invalid_leading_chars(string));
     }
 }

--- a/src/common/file_entry.rs
+++ b/src/common/file_entry.rs
@@ -22,10 +22,7 @@ impl fmt::Display for FileEntry {
 impl FileEntry {
     /// Converts `PathBuf` to tuple of `(FileEntry, Vec<String>)`
     pub fn from(path: PathBuf) -> Option<(Self, Vec<String>)> {
-        let file_name = match Self::get_file_name(&path) {
-            Some(s) => s,
-            None => return None,
-        };
+        let file_name = Self::get_file_name(&path)?.to_string();
 
         let content = match fs::read_to_string(&path) {
             Ok(content) => content,

--- a/src/common/file_entry.rs
+++ b/src/common/file_entry.rs
@@ -55,7 +55,7 @@ impl FileEntry {
             .is_some()
     }
 
-    fn get_file_name<'a>(path: &'a PathBuf) -> Option<&'a str> {
+    fn get_file_name(path: &PathBuf) -> Option<&str> {
         path.file_name().and_then(|file_name| file_name.to_str())
     }
 }

--- a/src/common/file_entry.rs
+++ b/src/common/file_entry.rs
@@ -53,16 +53,13 @@ impl FileEntry {
     pub fn is_env_file(path: &PathBuf) -> bool {
         let pattern = ".env";
         Self::get_file_name(path)
-            .filter(|file_name| !EXCLUDED_FILES.contains(&file_name.as_str()))
+            .filter(|file_name| !EXCLUDED_FILES.contains(file_name))
             .filter(|file_name| file_name.starts_with(pattern) || file_name.ends_with(pattern))
             .is_some()
     }
 
-    fn get_file_name(path: &PathBuf) -> Option<String> {
-        path.file_name()
-            .map(|file_name| file_name.to_str())
-            .unwrap_or(None)
-            .map(|s| s.to_string())
+    fn get_file_name<'a>(path: &'a PathBuf) -> Option<&'a str> {
+        path.file_name().and_then(|file_name| file_name.to_str())
     }
 }
 

--- a/src/common/file_entry.rs
+++ b/src/common/file_entry.rs
@@ -24,10 +24,7 @@ impl FileEntry {
     pub fn from(path: PathBuf) -> Option<(Self, Vec<String>)> {
         let file_name = Self::get_file_name(&path)?.to_string();
 
-        let content = match fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(_) => return None,
-        };
+        let content = fs::read_to_string(&path).ok()?;
 
         let mut lines: Vec<String> = content.lines().map(|line| line.to_string()).collect();
 

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -33,15 +33,14 @@ impl LineEntry {
         Some(stripped.split('=').next().unwrap_or(stripped))
     }
 
-    pub fn get_value(&self) -> Option<String> {
+    pub fn get_value(&self) -> Option<&str> {
         if self.is_empty_or_comment() {
             return None;
         }
 
-        match self.raw_string.find('=') {
-            Some(index) => Some(self.raw_string[(index + 1)..].to_owned()),
-            None => None,
-        }
+        self.raw_string
+            .find('=')
+            .map(|idx| &self.raw_string[(idx + 1)..])
     }
 
     pub fn trimmed_string(&self) -> &str {
@@ -166,7 +165,7 @@ mod tests {
         #[test]
         fn correct_line_test() {
             let input = line_entry(1, 1, "FOO=BAR");
-            let expected = Some(String::from("BAR"));
+            let expected = Some("BAR");
 
             assert_eq!(expected, input.get_value());
         }
@@ -174,7 +173,7 @@ mod tests {
         #[test]
         fn correct_line_with_single_quote_test() {
             let input = line_entry(1, 1, "FOO='BAR'");
-            let expected = Some(String::from("'BAR'"));
+            let expected = Some("'BAR'");
 
             assert_eq!(expected, input.get_value());
         }
@@ -182,7 +181,7 @@ mod tests {
         #[test]
         fn correct_line_with_double_quote_test() {
             let input = line_entry(1, 1, "FOO=\"BAR\"");
-            let expected = Some(String::from("\"BAR\""));
+            let expected = Some("\"BAR\"");
 
             assert_eq!(expected, input.get_value());
         }
@@ -190,7 +189,7 @@ mod tests {
         #[test]
         fn line_without_key_test() {
             let input = line_entry(1, 1, "=BAR");
-            let expected = Some(String::from("BAR"));
+            let expected = Some("BAR");
 
             assert_eq!(expected, input.get_value());
         }
@@ -198,7 +197,7 @@ mod tests {
         #[test]
         fn line_without_value_test() {
             let input = line_entry(1, 1, "FOO=");
-            let expected = Some(String::from(""));
+            let expected = Some("");
 
             assert_eq!(expected, input.get_value());
         }

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -48,10 +48,11 @@ impl LineEntry {
     }
 
     fn stripped_export_string(&self) -> &str {
-        match self.trimmed_string().strip_prefix("export ") {
-            Some(stripped_string) => stripped_string.trim(),
-            None => self.trimmed_string(),
-        }
+        let trimmed = self.trimmed_string();
+        trimmed
+            .strip_prefix("export ")
+            .map(str::trim)
+            .unwrap_or(trimmed)
     }
 
     pub fn is_last_line(&self) -> bool {

--- a/src/common/output/check.rs
+++ b/src/common/output/check.rs
@@ -51,17 +51,10 @@ impl CheckOutput {
 
             println!(
                 "\n{}",
-                format!(
-                    "{} {} {}",
-                    String::from("Found"),
-                    total.to_string(),
-                    problems
-                )
-                .red()
-                .bold()
+                format!("{} {} {}", "Found", total, problems).red().bold()
             );
         } else {
-            println!("\n{}", "No problems found".to_string().green().bold());
+            println!("\n{}", "No problems found".green().bold());
         }
     }
 }

--- a/src/common/warning.rs
+++ b/src/common/warning.rs
@@ -9,7 +9,7 @@ pub struct Warning {
     message: String,
 }
 
-impl<'a> Warning {
+impl Warning {
     pub fn new(line: LineEntry, check_name: impl Into<String>, message: impl Into<String>) -> Self {
         let check_name = check_name.into();
         let message = message.into();

--- a/src/common/warning.rs
+++ b/src/common/warning.rs
@@ -9,9 +9,10 @@ pub struct Warning {
     message: String,
 }
 
-impl Warning {
-    pub fn new(line: LineEntry, check_name: &str, message: String) -> Self {
-        let check_name = String::from(check_name);
+impl<'a> Warning {
+    pub fn new(line: LineEntry, check_name: impl Into<String>, message: impl Into<String>) -> Self {
+        let check_name = check_name.into();
+        let message = message.into();
         Self {
             line,
             check_name,
@@ -44,11 +45,7 @@ mod tests {
     #[test]
     fn warning_fmt_test() {
         let line = line_entry(1, 1, "FOO=BAR");
-        let warning = Warning::new(
-            line,
-            "DuplicatedKey",
-            String::from("The FOO key is duplicated"),
-        );
+        let warning = Warning::new(line, "DuplicatedKey", "The FOO key is duplicated");
 
         assert_eq!(
             format!(

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -113,7 +113,7 @@ mod tests {
         let mut warnings = vec![Warning::new(
             lines[1].clone(),
             "LowercaseKey",
-            String::from("The c key should be in uppercase"),
+            "The c key should be in uppercase",
         )];
 
         assert_eq!(1, run(&mut warnings, &mut lines, &[]));
@@ -130,7 +130,7 @@ mod tests {
         let mut warnings = vec![Warning::new(
             lines[1].clone(),
             "Unfixable",
-            String::from("The UNFIXABLE- key is not fixable"),
+            "The UNFIXABLE- key is not fixable",
         )];
 
         assert_eq!(0, run(&mut warnings, &mut lines, &[]));
@@ -147,12 +147,12 @@ mod tests {
             Warning::new(
                 lines[0].clone(),
                 "LowercaseKey",
-                String::from("The a key should be in uppercase"),
+                "The a key should be in uppercase",
             ),
             Warning::new(
                 lines[1].clone(),
                 "LowercaseKey",
-                String::from("The c key should be in uppercase"),
+                "The c key should be in uppercase",
             ),
         ];
 
@@ -172,12 +172,12 @@ mod tests {
             Warning::new(
                 lines[2].clone(),
                 "LowercaseKey",
-                String::from("The a0 key should be in uppercase"),
+                "The a0 key should be in uppercase",
             ),
             Warning::new(
                 lines[3].clone(),
                 "LowercaseKey",
-                String::from("The a2 key should be in uppercase"),
+                "The a2 key should be in uppercase",
             ),
         ];
 
@@ -202,12 +202,12 @@ mod tests {
             Warning::new(
                 lines[2].clone(),
                 "LowercaseKey",
-                String::from("The a0 key should be in uppercase"),
+                "The a0 key should be in uppercase",
             ),
             Warning::new(
                 lines[3].clone(),
                 "LowercaseKey",
-                String::from("The a2 key should be in uppercase"),
+                "The a2 key should be in uppercase",
             ),
         ];
 
@@ -232,12 +232,12 @@ mod tests {
             Warning::new(
                 lines[2].clone(),
                 "LowercaseKey",
-                String::from("The a0 key should be in uppercase"),
+                "The a0 key should be in uppercase",
             ),
             Warning::new(
                 lines[3].clone(),
                 "LowercaseKey",
-                String::from("The a2 key should be in uppercase"),
+                "The a2 key should be in uppercase",
             ),
         ];
 

--- a/src/fixes/duplicated_key.rs
+++ b/src/fixes/duplicated_key.rs
@@ -74,13 +74,9 @@ mod tests {
             Warning::new(
                 lines[2].clone(),
                 "DuplicatedKey",
-                "The FOO key is duplicated".to_owned(),
+                "The FOO key is duplicated",
             ),
-            Warning::new(
-                lines[3].clone(),
-                "DuplicatedKey",
-                "The Z key is duplicated".to_owned(),
-            ),
+            Warning::new(lines[3].clone(), "DuplicatedKey", "The Z key is duplicated"),
         ];
 
         assert_eq!(

--- a/src/fixes/duplicated_key.rs
+++ b/src/fixes/duplicated_key.rs
@@ -37,11 +37,11 @@ impl Fix for DuplicatedKeyFixer<'_> {
                 continue;
             }
 
-            if let Some(key) = line.get_key().map(str::to_string) {
-                if keys.contains(&key) {
+            if let Some(key) = line.get_key() {
+                if keys.contains(key) {
                     self.fix_line(line)?;
                 } else {
-                    keys.insert(key);
+                    keys.insert(key.to_string());
                 }
             }
         }

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -23,13 +23,13 @@ impl Fix for EndingBlankLineFixer<'_> {
         _warnings: Vec<&mut Warning>,
         lines: &mut Vec<LineEntry>,
     ) -> Option<usize> {
-        let file = lines.first()?.file.clone();
         let last_line = lines.last()?;
 
         if last_line.raw_string.ends_with(LF) {
             return Some(0);
         }
 
+        let file = lines.first()?.file.clone();
         lines.push(LineEntry {
             number: lines.len() + 1,
             file,

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -53,7 +53,7 @@ mod tests {
         let mut warning = Warning::new(
             lines[1].clone(),
             "EndingBlankLine",
-            String::from("No blank line at the end of the file"),
+            "No blank line at the end of the file",
         );
 
         assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));

--- a/src/fixes/extra_blank_line.rs
+++ b/src/fixes/extra_blank_line.rs
@@ -53,11 +53,8 @@ mod tests {
         let line2 = line_entry(2, 4, "");
         let line3 = line_entry(3, 4, "");
         let line4 = line_entry(4, 4, "HOGE=HUGA");
-        let mut warning = Warning::new(
-            line3.clone(),
-            "ExtraBlankLine",
-            "Extra blank line detected".to_string(),
-        );
+        let mut warning =
+            Warning::new(line3.clone(), "ExtraBlankLine", "Extra blank line detected");
         let warnings = vec![&mut warning];
         let mut lines = vec![line1.clone(), line2.clone(), line3.clone(), line4.clone()];
         assert_eq!(Some(1), fixer.fix_warnings(warnings, &mut lines));
@@ -72,16 +69,10 @@ mod tests {
         let line3 = line_entry(3, 5, "");
         let line4 = line_entry(4, 5, "");
         let line5 = line_entry(5, 5, "HOGE=HUGA");
-        let mut warning1 = Warning::new(
-            line3.clone(),
-            "ExtraBlankLine",
-            "Extra blank line detected".to_string(),
-        );
-        let mut warning2 = Warning::new(
-            line4.clone(),
-            "ExtraBlankLine",
-            "Extra blank line detected".to_string(),
-        );
+        let mut warning1 =
+            Warning::new(line3.clone(), "ExtraBlankLine", "Extra blank line detected");
+        let mut warning2 =
+            Warning::new(line4.clone(), "ExtraBlankLine", "Extra blank line detected");
         let warnings = vec![&mut warning1, &mut warning2];
         let mut lines = vec![
             line1.clone(),

--- a/src/fixes/incorrect_delimiter.rs
+++ b/src/fixes/incorrect_delimiter.rs
@@ -24,15 +24,9 @@ impl Fix for IncorrectDelimiterFixer<'_> {
         let cleaned_key = remove_invalid_leading_chars(&key);
         let start_idx = key.len() - cleaned_key.len();
 
-        let cleaned_key: String = key
-            .chars()
-            .skip(start_idx)
-            .map(|c| if c.is_alphanumeric() { c } else { '_' })
-            .collect();
+        let cleaned_key = key[start_idx..].replace(|c: char| !c.is_alphanumeric(), "_");
 
-        let fixed_key = key[..start_idx].to_string() + &cleaned_key;
-
-        line.raw_string = format!("{}={}", fixed_key, line.get_value()?);
+        line.raw_string = format!("{}{}={}", &key[..start_idx], cleaned_key, line.get_value()?);
 
         Some(())
     }

--- a/src/fixes/incorrect_delimiter.rs
+++ b/src/fixes/incorrect_delimiter.rs
@@ -81,7 +81,7 @@ mod tests {
         let mut warning = Warning::new(
             lines[0].clone(),
             "IncorrectDelimiter",
-            String::from("The RAILS-ENV key has has an incorrect delimter"),
+            "The RAILS-ENV key has has an incorrect delimter",
         );
 
         assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));

--- a/src/fixes/key_without_value.rs
+++ b/src/fixes/key_without_value.rs
@@ -50,7 +50,7 @@ mod tests {
         let mut warning = Warning::new(
             lines[0].clone(),
             "KeyWithoutValue",
-            String::from("The FOO key should be with a value or have an equal sign"),
+            "The FOO key should be with a value or have an equal sign",
         );
 
         assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));

--- a/src/fixes/leading_character.rs
+++ b/src/fixes/leading_character.rs
@@ -114,22 +114,22 @@ mod tests {
             Warning::new(
                 lines[0].clone(),
                 "LeadingCharacter",
-                String::from("Invalid leading character detected"),
+                "Invalid leading character detected",
             ),
             Warning::new(
                 lines[1].clone(),
                 "LeadingCharacter",
-                String::from("Invalid leading character detected"),
+                "Invalid leading character detected",
             ),
             Warning::new(
                 lines[2].clone(),
                 "LeadingCharacter",
-                String::from("Invalid leading character detected"),
+                "Invalid leading character detected",
             ),
             Warning::new(
                 lines[3].clone(),
                 "LeadingCharacter",
-                String::from("Invalid leading character detected"),
+                "Invalid leading character detected",
             ),
         ];
 

--- a/src/fixes/quote_character.rs
+++ b/src/fixes/quote_character.rs
@@ -53,7 +53,7 @@ mod tests {
         let mut warning = Warning::new(
             lines[0].clone(),
             "QuoteCharacter",
-            String::from("The value has quote characters (\', \")"),
+            "The value has quote characters (\', \")",
         );
 
         assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));

--- a/src/fixes/space_character.rs
+++ b/src/fixes/space_character.rs
@@ -62,12 +62,12 @@ mod tests {
             Warning::new(
                 lines[0].clone(),
                 "SpaceCharacter",
-                String::from("The line has spaces around equal sign"),
+                "The line has spaces around equal sign",
             ),
             Warning::new(
                 lines[1].clone(),
                 "SpaceCharacter",
-                String::from("The line has spaces around equal sign"),
+                "The line has spaces around equal sign",
             ),
         ];
 

--- a/src/fixes/trailing_whitespace.rs
+++ b/src/fixes/trailing_whitespace.rs
@@ -50,7 +50,7 @@ mod tests {
         let mut warning = Warning::new(
             lines[0].clone(),
             "TrailingWhitespace",
-            String::from("Trailing whitespace detected"),
+            "Trailing whitespace detected",
         );
 
         assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));

--- a/src/fixes/unordered_key.rs
+++ b/src/fixes/unordered_key.rs
@@ -125,7 +125,7 @@ mod tests {
     fn get_warnings(lines: &[LineEntry], warnings: Vec<(usize, &str)>) -> Vec<Warning> {
         warnings
             .into_iter()
-            .map(|(i, line)| Warning::new(lines[i].clone(), "UnorderedKey", String::from(line)))
+            .map(|(i, line)| Warning::new(lines[i].clone(), "UnorderedKey", line))
             .collect()
     }
 

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -57,10 +57,10 @@ pub fn backup_file(fe: &FileEntry) -> Result<PathBuf, Box<dyn Error>> {
     let mut new_path = fe.path.to_owned();
     new_path.set_file_name(format!("{}_{}", &fe.file_name, timestamp));
 
-    match copy(&fe.path, &new_path) {
-        Ok(_) => Ok(new_path),
-        Err(e) => Err(Box::new(e)),
-    }
+    copy(&fe.path, &new_path)
+        .map(|_| new_path)
+        .map_err(Box::new)
+        .map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -126,9 +126,9 @@ mod tests {
     fn test_canonicalize() {
         const UNC_PREFIX: &str = "\\\\?\\";
 
-        let file_name = String::from(".env");
+        let file_name = ".env";
         let dir = tempfile::tempdir().expect("create temp dir");
-        let path = dir.path().join(&file_name);
+        let path = dir.path().join(file_name);
         File::create(&path).expect("create testfile");
 
         let dunce_canonical_path = dunce::canonicalize(&path).expect("canonical path by `dunce`");
@@ -148,9 +148,9 @@ mod tests {
 
     #[test]
     fn write_file_test() {
-        let file_name = String::from(".env");
+        let file_name = ".env";
         let dir = tempfile::tempdir().expect("create temp dir");
-        let path = dir.path().join(&file_name);
+        let path = dir.path().join(file_name);
 
         let lines = vec![
             line_entry(1, 3, "A=B"),

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -18,19 +18,16 @@ pub fn get_relative_path(target_path: &PathBuf, base_path: &PathBuf) -> Option<P
     let comp_target: Vec<_> = target_path.components().collect();
     let comp_base: Vec<_> = base_path.components().collect();
 
-    let mut i = 0;
-    for (b, t) in comp_base.iter().zip(comp_target.iter()) {
-        if b != t {
-            break;
-        }
-        i += 1;
-    }
+    let i = comp_base
+        .iter()
+        .zip(comp_target.iter())
+        .take_while(|(b, t)| b == t)
+        .count();
 
-    let mut relative_path = PathBuf::new();
-
-    for _ in 0..(comp_base.len() - i) {
-        relative_path.push("..");
-    }
+    let mut relative_path = (0..(comp_base.len() - i)).fold(PathBuf::new(), |mut acc, _| {
+        acc.push("..");
+        acc
+    });
     relative_path.extend(comp_target.get(i..)?);
 
     Some(relative_path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,6 @@ fn get_lines(
 ) -> Result<BTreeMap<FileEntry, Vec<String>>, Box<dyn Error>> {
     let file_paths: Vec<PathBuf> = get_needed_file_paths(args);
 
-    if file_paths.is_empty() {
-        return Ok(BTreeMap::new());
-    }
-
     Ok(file_paths
         .iter()
         .map(|path| fs_utils::get_relative_path(&path, &current_dir).and_then(FileEntry::from))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,28 +87,18 @@ fn get_lines(
     args: &clap::ArgMatches,
     current_dir: &PathBuf,
 ) -> Result<BTreeMap<FileEntry, Vec<String>>, Box<dyn Error>> {
-    let mut lines: BTreeMap<FileEntry, Vec<String>> = BTreeMap::new();
     let file_paths: Vec<PathBuf> = get_needed_file_paths(args);
 
     if file_paths.is_empty() {
-        return Ok(lines);
+        return Ok(BTreeMap::new());
     }
 
-    for path in file_paths.iter() {
-        let relative_path = match fs_utils::get_relative_path(&path, &current_dir) {
-            Some(p) => p,
-            None => continue,
-        };
-
-        let (fe, strings) = match FileEntry::from(relative_path) {
-            Some(f) => f,
-            None => continue,
-        };
-
-        lines.insert(fe, strings);
-    }
-
-    Ok(lines)
+    Ok(file_paths
+        .iter()
+        .map(|path| fs_utils::get_relative_path(&path, &current_dir).and_then(FileEntry::from))
+        .filter(Option::is_some)
+        .map(Option::unwrap)
+        .collect::<BTreeMap<_, _>>())
 }
 
 /// getting a list of all files for checking/fixing without custom exclusion files

--- a/tests/args/specific_path.rs
+++ b/tests/args/specific_path.rs
@@ -9,7 +9,7 @@ fn checks_one_specific_path() {
     let subdir = testdir.subdir();
     let testfile_2 = subdir.create_testfile(".env.test", "1FOO=\n");
     let testfile_2_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_2.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -35,7 +35,7 @@ fn checks_two_specific_paths() {
     let subdir_1 = testdir.subdir();
     let testfile_2 = subdir_1.create_testfile(".env", " FOO=\n");
     let testfile_2_pathbuf =
-        Path::new(&testdir.relative_path(&subdir_1)).join(testfile_2.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir_1).as_ref()).join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -43,7 +43,7 @@ fn checks_two_specific_paths() {
     let subdir_2 = subdir_1.subdir();
     let testfile_3 = subdir_2.create_testfile(".env", " FOO=\n");
     let testfile_3_pathbuf =
-        Path::new(&testdir.relative_path(&subdir_2)).join(testfile_3.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir_2).as_ref()).join(testfile_3.shortname_as_str());
     let testfile_3_path = testfile_3_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -99,7 +99,7 @@ fn checks_two_specific_files() {
     let subdir = testdir.subdir();
     let testfile_3 = subdir.create_testfile("another_test_file", "FOO=BAR\nFOO=BAR\n");
     let testfile_3_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_3.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_3.shortname_as_str());
     let testfile_3_path = testfile_3_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -134,14 +134,14 @@ fn checks_each_file_only_once_when_listing_same_path_twice() {
     let subdir = testdir.subdir();
     let testfile_1 = subdir.create_testfile(".env.a", " FOO=\n");
     let testfile_1_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_1.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_1.shortname_as_str());
     let testfile_1_path = testfile_1_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
 
     let testfile_2 = subdir.create_testfile(".env.b", "FOO=BAR\nBAR=foo\n");
     let testfile_2_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_2.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -176,13 +176,13 @@ fn checks_each_file_only_once_when_listing_one_path_and_one_file() {
     let subdir = testdir.subdir();
     let testfile_1 = subdir.create_testfile(".env.a", " FOO=\n");
     let testfile_1_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_1.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_1.shortname_as_str());
     let testfile_1_path = testfile_1_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
     let testfile_2 = subdir.create_testfile(".env.b", "FOO=val\nBAR=foo\n");
     let testfile_2_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_2.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -219,7 +219,7 @@ fn checks_one_specific_file_and_one_path() {
     let subdir = testdir.subdir();
     let testfile_3 = subdir.create_testfile("test.env", "FOO=BAR\nFOO=BAR\n");
     let testfile_3_pathbuf =
-        Path::new(&testdir.relative_path(&subdir)).join(testfile_3.shortname_as_str());
+        Path::new(&testdir.relative_path(&subdir).as_ref()).join(testfile_3.shortname_as_str());
     let testfile_3_path = testfile_3_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");

--- a/tests/common/test_dir.rs
+++ b/tests/common/test_dir.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use std::ffi::OsStr;
+use std::{borrow::Cow, ffi::OsStr};
 use tempfile::{tempdir, tempdir_in, TempDir};
 
 #[cfg(windows)]
@@ -37,14 +37,13 @@ impl TestDir {
     }
 
     /// Get relative path between TestDir and a subdirectory TestDir
-    pub fn relative_path(&self, subdir: &Self) -> String {
+    pub fn relative_path<'a>(&self, subdir: &'a Self) -> Cow<'a, str> {
         subdir
             .current_dir
             .path()
             .strip_prefix(self.current_dir.path())
             .expect("strip dir from subdir path")
             .to_string_lossy()
-            .to_string()
     }
 
     /// Create a TestFile within the TestDir
@@ -203,7 +202,6 @@ impl TestDir {
                     .success()
                     .get_output()
                     .stdout
-                    .clone()
                     .as_slice(),
             )
             .expect("convert to &str"),

--- a/tests/flags/recursive.rs
+++ b/tests/flags/recursive.rs
@@ -7,8 +7,8 @@ fn checks_one_in_subdir() {
     test_dir.create_testfile("correct.env", "FOO=BAR\n");
     let test_subdir = test_dir.subdir();
     let testfile_2 = test_subdir.create_testfile(".incorrect.env", "1BAR=\n");
-    let testfile_2_pathbuf =
-        Path::new(&test_dir.relative_path(&test_subdir)).join(testfile_2.shortname_as_str());
+    let testfile_2_pathbuf = Path::new(&test_dir.relative_path(&test_subdir).as_ref())
+        .join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -36,16 +36,16 @@ fn checks_files_in_deep_subdirs() {
 
     let test_subdir_2 = test_dir.subdir();
     let testfile_2 = test_subdir_2.create_testfile("incorrect.sub_1.env", "FOO=BAR\nBAR=FOO\n");
-    let testfile_2_pathbuf =
-        Path::new(&test_dir.relative_path(&test_subdir_2)).join(testfile_2.shortname_as_str());
+    let testfile_2_pathbuf = Path::new(&test_dir.relative_path(&test_subdir_2).as_ref())
+        .join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
 
     let test_subdir_3 = test_subdir_2.subdir();
     let testfile_3 = test_subdir_3.create_testfile(".incorrect.env", "FOO=");
-    let testfile_3_pathbuf =
-        Path::new(&test_dir.relative_path(&test_subdir_3)).join(testfile_3.shortname_as_str());
+    let testfile_3_pathbuf = Path::new(&test_dir.relative_path(&test_subdir_3).as_ref())
+        .join(testfile_3.shortname_as_str());
     let testfile_3_path = testfile_3_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -94,8 +94,8 @@ fn checks_recursive_with_exclude_subdir() {
 
     let test_subdir_2 = test_dir.subdir();
     let testfile_2 = test_subdir_2.create_testfile("incorrect.sub_1.env", "FOO=BAR\nBAR=FOO\n");
-    let testfile_2_pathbuf =
-        Path::new(&test_dir.relative_path(&test_subdir_2)).join(testfile_2.shortname_as_str());
+    let testfile_2_pathbuf = Path::new(&test_dir.relative_path(&test_subdir_2).as_ref())
+        .join(testfile_2.shortname_as_str());
     let testfile_2_path = testfile_2_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");
@@ -125,7 +125,7 @@ fn checks_nofollow_subdir_symlinks() {
     let test_subdir = test_dir.subdir();
     let testfile = test_subdir.create_testfile(".incorrect.env", "1BAR=\n");
     let testfile_pathbuf =
-        Path::new(&test_dir.relative_path(&test_subdir)).join(testfile.shortname_as_str());
+        Path::new(&test_dir.relative_path(&test_subdir).as_ref()).join(testfile.shortname_as_str());
     let testfile_path = testfile_pathbuf
         .to_str()
         .expect("multi-platform path to test .env file");

--- a/tests/output/fix.rs
+++ b/tests/output/fix.rs
@@ -185,10 +185,8 @@ fn backup() {
         .filter(|e| e.path().as_os_str() != test_file.as_str())
         .last()
         .expect("get backup file");
-    let backup_filename = backup_file
-        .file_name()
-        .into_string()
-        .expect("convert to string");
+    let backup_filename = backup_file.file_name();
+    let backup_filename = backup_filename.to_str().expect("convert to string");
     let expected_output = format!(
         r#"Fixing .env
 Original file was backed up to: "{}"
@@ -219,10 +217,8 @@ fn quiet_backup() {
         .filter(|e| e.path().as_os_str() != test_file.as_str())
         .last()
         .expect("get backup file");
-    let backup_filename = backup_file
-        .file_name()
-        .into_string()
-        .expect("convert to string");
+    let backup_filename = backup_file.file_name();
+    let backup_filename = backup_filename.to_str().expect("convert to string");
     let expected_output = format!(
         r#"Original file was backed up to: "{}"
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Another PR by me :)

When working on my last change, I saw a few unnecessary `clone`s, `to_string`s, `to_owned`s and so on. This change tries to remove them where possible and therefore improve the runtime performance by getting rid of a few heap allocations and memory copies.

There are no new features, so I didn't write new tests, but the existing tests still pass :)

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
