### PR TITLE
feat: dont lint backup files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Add `.bak` extension to backup files and don't lint backup files [#367](https://github.com/dotenv-linter/dotenv-linter/pull/367) ([@mstruebing](https://github.com/mstruebing))
 - Add `.env` explanation [#363](https://github.com/dotenv-linter/dotenv-linter/pull/363) ([@henryboisdequin](https://github.com/henryboisdequin))
 
 ## [v3.0.0] - 2021-01-11

--- a/src/common/file_entry.rs
+++ b/src/common/file_entry.rs
@@ -49,6 +49,7 @@ impl FileEntry {
         Self::get_file_name(path)
             .filter(|file_name| !EXCLUDED_FILES.contains(file_name))
             .filter(|file_name| file_name.starts_with(pattern) || file_name.ends_with(pattern))
+            .filter(|file_name| !file_name.ends_with(".bak"))
             .is_some()
     }
 
@@ -106,6 +107,7 @@ mod tests {
             ("foo-env", false),
             (".my-env-file", false),
             ("dev.env.js", false),
+            (".env.bak", false),
         ];
 
         assertions.extend(EXCLUDED_FILES.iter().map(|file| (*file, false)));

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -52,7 +52,7 @@ pub fn backup_file(fe: &FileEntry) -> Result<PathBuf, Box<dyn Error>> {
         .as_secs();
 
     let mut new_path = fe.path.to_owned();
-    new_path.set_file_name(format!("{}_{}", &fe.file_name, timestamp));
+    new_path.set_file_name(format!("{}_{}.bak", &fe.file_name, timestamp));
 
     copy(&fe.path, &new_path)
         .map(|_| new_path)

--- a/tests/flags/backup.rs
+++ b/tests/flags/backup.rs
@@ -22,6 +22,7 @@ fn output_backup_file() {
 
     assert_eq!(backup_contents, content);
     assert_eq!(testfile.contents(), "FOO=bar\n");
+    assert_eq!(backup_file.path().extension().unwrap(), "bak");
 
     testdir.close()
 }


### PR DESCRIPTION
also:
    * add `.bak` extension to backup files

What are your thoughts on this solution @dotenv-linter/core - is this the right way to do it?

closes #359 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
