### PR TITLE
fix: remove extra Result wrapping to fix clippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Remove `Result` from the return type [#374](https://github.com/dotenv-linter/dotenv-linter/pull/374) ([@DDtKey](https://github.com/DDtKey))
 - Add `.bak` extension to backup files and don't lint backup files [#367](https://github.com/dotenv-linter/dotenv-linter/pull/367) ([@mstruebing](https://github.com/mstruebing))
 - Add `.env` explanation [#363](https://github.com/dotenv-linter/dotenv-linter/pull/363) ([@henryboisdequin](https://github.com/henryboisdequin))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use checks::available_check_names;
 use common::CompareWarning;
 
 pub fn check(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<usize, Box<dyn Error>> {
-    let lines_map = get_lines(args, current_dir)?;
+    let lines_map = get_lines(args, current_dir);
 
     // Nothing to check
     if lines_map.is_empty() {
@@ -47,7 +47,7 @@ pub fn check(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<usize, Bo
 
 pub fn fix(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<(), Box<dyn Error>> {
     let mut warnings_count = 0;
-    let lines_map = get_lines(args, current_dir)?;
+    let lines_map = get_lines(args, current_dir);
 
     // Nothing to fix
     if lines_map.is_empty() {
@@ -88,18 +88,15 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<(), Box<dyn
     Ok(())
 }
 
-fn get_lines(
-    args: &clap::ArgMatches,
-    current_dir: &PathBuf,
-) -> Result<BTreeMap<FileEntry, Vec<String>>, Box<dyn Error>> {
+fn get_lines(args: &clap::ArgMatches, current_dir: &PathBuf) -> BTreeMap<FileEntry, Vec<String>> {
     let file_paths: Vec<PathBuf> = get_needed_file_paths(args);
 
-    Ok(file_paths
+    file_paths
         .iter()
         .map(|path| fs_utils::get_relative_path(&path, &current_dir).and_then(FileEntry::from))
         .filter(Option::is_some)
         .map(Option::unwrap)
-        .collect::<BTreeMap<_, _>>())
+        .collect::<BTreeMap<_, _>>()
 }
 
 /// getting a list of all files for checking/fixing without custom exclusion files
@@ -133,7 +130,7 @@ pub fn compare(
     current_dir: &PathBuf,
 ) -> Result<Vec<CompareWarning>, Box<dyn Error>> {
     let mut all_keys: HashSet<String> = HashSet::new();
-    let lines_map = get_lines(args, current_dir)?;
+    let lines_map = get_lines(args, current_dir);
     let output = CompareOutput::new(args.is_present("quiet"));
 
     let mut warnings: Vec<CompareWarning> = Vec::new();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
This is a pretty simple solution, but I would not like to see the `CI failing` status for a long time 🙂 
Closes #373 
<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
