### PR TITLE
ci: use clippy check action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 # Github workflow files do not support YAML anchors.
-
 name: CI
 on:
   push:
@@ -11,6 +10,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  ##################
+  ### Linux jobs ###
+  ##################
   check:
     name: Check / Linux
     runs-on: ubuntu-latest
@@ -76,29 +78,16 @@ jobs:
             ~/.cargo/registry
             target
           key: clippy-linux-${{ steps.toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Check with Clippy
-        uses: actions-rs/cargo@v1
+      - uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
-          args: -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features -- -D warnings
       - name: Cleanup for caching
         uses: actions-rs/cargo@v1
         with:
           command: clean
           args: --package dotenv-linter
         if: steps.cache-target.outputs.cache-hit != 'true'
-  #   - uses: actions-rs/clippy-check@v1
-  #     with:
-  #       token: ${{ secrets.GITHUB_TOKEN }}
-  #       args: --all-features -- -D warnings
-
-  docker:
-    name: Build / Docker
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Build
-        run: docker build --target builder .
 
   build:
     name: Build / Linux
@@ -182,7 +171,7 @@ jobs:
           args: --package dotenv-linter
         if: steps.cache-target.outputs.cache-hit != 'true'
 
-  linux_install:
+  install:
     name: Install / Linux
     runs-on: ubuntu-latest
     steps:
@@ -194,6 +183,9 @@ jobs:
       - name: Verify successful installation
         run: $HOME/bin/dotenv-linter -v
 
+  ####################
+  ### Windows jobs ###
+  ####################
   windows_build:
     name: Build / Windows
     runs-on: windows-latest
@@ -221,7 +213,7 @@ jobs:
           command: clean
           args: --package dotenv-linter
         if: steps.cache-target.outputs.cache-hit != 'true'
-
+  
   windows_test:
     name: Test / Windows
     runs-on: windows-latest
@@ -268,6 +260,9 @@ jobs:
         shell: bash
         run: $HOME/bin/dotenv-linter.exe -v
 
+  ##################
+  ### macOS jobs ###
+  ##################
   macos_install:
     name: Install / MacOS
     runs-on: macos-latest
@@ -279,3 +274,14 @@ jobs:
           sh "${GITHUB_WORKSPACE}/install.sh" -b $HOME/bin
       - name: Verify successful installation
         run: $HOME/bin/dotenv-linter -v
+
+  ###################
+  ### Docker jobs ###
+  ###################
+  docker_build:
+    name: Build / Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: docker build --target builder .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Use GitHub action [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) to run clippy [#375](https://github.com/dotenv-linter/dotenv-linter/pull/375) ([@mgrachev](https://github.com/mgrachev))
 - Remove `Result` from the return type [#374](https://github.com/dotenv-linter/dotenv-linter/pull/374) ([@DDtKey](https://github.com/DDtKey))
 - Add `.bak` extension to backup files and don't lint backup files [#367](https://github.com/dotenv-linter/dotenv-linter/pull/367) ([@mstruebing](https://github.com/mstruebing))
 - Add `.env` explanation [#363](https://github.com/dotenv-linter/dotenv-linter/pull/363) ([@henryboisdequin](https://github.com/henryboisdequin))


### PR DESCRIPTION
The [clippy-check](https://github.com/actions-rs/clippy-check) action allows to execute `clippy` and posts all warnings as annotations to PR's.

I think it's very useful to see all the warnings on the `Files changed` tab, instead of looking for them in the logs.

Example:
<img width="433" alt="Screenshot 2021-03-12 at 15 36 03" src="https://user-images.githubusercontent.com/700998/110942994-afca7900-834b-11eb-9811-1a4bd5c22c62.png">

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
