### PR TITLE
Add method to get substitution keys to LineEntry (#379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add method to get substitution keys to LineEntry [#379](https://github.com/dotenv-linter/dotenv-linter/issues/379) ([@zotho](https://github.com/zotho))
 - Add a GitHub Action to compare benchmarks [#378](https://github.com/dotenv-linter/dotenv-linter/pull/378) ([@mgrachev](https://github.com/mgrachev))
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Add method to get substitution keys to LineEntry [#379](https://github.com/dotenv-linter/dotenv-linter/issues/379) ([@zotho](https://github.com/zotho))
+- Add method to get substitution keys to LineEntry [#391](https://github.com/dotenv-linter/dotenv-linter/pull/391) ([@zotho](https://github.com/zotho))
 - Add a GitHub Action to compare benchmarks [#378](https://github.com/dotenv-linter/dotenv-linter/pull/378) ([@mgrachev](https://github.com/mgrachev))
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -73,6 +73,7 @@ impl LineEntry {
         comment::parse(self.raw_string.as_str())
     }
 
+    #[allow(dead_code)]
     pub fn get_substitution_key(&self) -> Result<Vec<&str>, &'static str> {
         let mut keys = Vec::new();
 

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -126,7 +126,6 @@ impl LineEntry {
                 }
 
                 keys.push(key);
-
                 value = rest;
             }
         }

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -74,7 +74,7 @@ impl LineEntry {
     }
 
     #[allow(dead_code)]
-    pub fn get_substitution_key(&self) -> Vec<&str> {
+    pub fn get_substitution_keys(&self) -> Vec<&str> {
         let mut keys = Vec::new();
 
         let mut value = match self.get_value() {
@@ -309,97 +309,97 @@ mod tests {
         }
     }
 
-    mod get_substitution_key {
+    mod get_substitution_keys {
         use super::*;
 
         #[test]
         fn run_with_empty() {
             let input = line_entry(1, 1, "");
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
         }
 
         #[test]
         fn run_with_simple() {
             let input = line_entry(1, 1, "FOO=$BAR");
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
         }
 
         #[test]
         fn run_with_simple_comment() {
             let input = line_entry(1, 1, "FOO=$BAR # comment");
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
         }
 
         #[test]
         fn run_with_curly_braces() {
             let input = line_entry(1, 1, "FOO=${BAR}");
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
 
             let input = line_entry(1, 1, "FOO=$BAR}");
-            assert_eq!(input.get_substitution_key(), vec!["BAR}"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR}"]);
 
             let input = line_entry(1, 1, "FOO=${BAR");
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
         }
 
         #[test]
         fn run_with_double_quotes() {
             let input = line_entry(1, 1, r#"FOO="$BAR""#);
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
 
             let input = line_entry(1, 1, r#"FOO=$BAR""#);
-            assert_eq!(input.get_substitution_key(), vec!["BAR\""]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR\""]);
 
             let input = line_entry(1, 1, r#"FOO="$BAR"#);
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
 
             let input = line_entry(1, 1, r#"FOO="$BAR\""#);
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
 
             let input = line_entry(1, 1, r#"FOO="\""#);
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
 
             let input = line_entry(1, 1, r#"FOO="${BAR}\\""#);
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
         }
 
         #[test]
         fn run_with_single_quotes() {
             let input = line_entry(1, 1, "FOO='$BAR'");
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
 
             let input = line_entry(1, 1, r"FOO=TEST_${BAR}_\'");
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
         }
 
         #[test]
         fn run_with_escaped_dollar() {
             let input = line_entry(1, 1, r"FOO=\$BAR");
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
 
             let input = line_entry(1, 1, r"FOO=\\$BAR");
-            assert_eq!(input.get_substitution_key(), vec!["BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
 
             let input = line_entry(1, 1, r"FOO=\\\$BAR");
-            assert!(input.get_substitution_key().is_empty());
+            assert!(input.get_substitution_keys().is_empty());
         }
 
         #[test]
         fn run_with_complicated() {
             let input = line_entry(1, 1, "DATABASE=postgres://${USER}@localhost/database");
-            assert_eq!(input.get_substitution_key(), vec!["USER"]);
+            assert_eq!(input.get_substitution_keys(), vec!["USER"]);
         }
 
         #[test]
         fn run_with_reused() {
             let input = line_entry(1, 1, "FOO=$BAR$BAR");
-            assert_eq!(input.get_substitution_key(), vec!["BAR", "BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR", "BAR"]);
 
             let input = line_entry(1, 1, "FOO=${BAR}${BAR}");
-            assert_eq!(input.get_substitution_key(), vec!["BAR", "BAR"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR", "BAR"]);
 
             let input = line_entry(1, 1, "FOO=${BAR}${BAZ}");
-            assert_eq!(input.get_substitution_key(), vec!["BAR", "BAZ"]);
+            assert_eq!(input.get_substitution_keys(), vec!["BAR", "BAZ"]);
         }
     }
 }

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -82,11 +82,11 @@ impl LineEntry {
             _ => return keys,
         };
 
-        let escaped =
+        let is_escaped =
             |prefix: &str| prefix.chars().rev().take_while(|ch| *ch == '\\').count() % 2 == 1;
 
         if value.starts_with('\"') {
-            if value.ends_with('\"') && !escaped(&value[..value.len() - 1]) {
+            if value.ends_with('\"') && !is_escaped(&value[..value.len() - 1]) {
                 value = &value[1..value.len() - 1]
             } else {
                 return keys;
@@ -97,7 +97,7 @@ impl LineEntry {
             let prefix = &value[..index];
             let raw_key = &value[index + 1..];
 
-            if escaped(prefix) {
+            if is_escaped(prefix) {
                 value = &raw_key;
             } else {
                 let (key, rest) = raw_key

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -121,11 +121,11 @@ impl LineEntry {
                             .map(|i| raw_key.split_at(i))
                     })
                     .unwrap_or((raw_key, ""));
-                if !key.is_empty() {
-                    keys.push(key);
-                } else {
+                if key.is_empty() {
                     return keys;
                 }
+
+                keys.push(key);
 
                 value = rest;
             }


### PR DESCRIPTION
Implements https://github.com/dotenv-linter/dotenv-linter/issues/379.

I decided to change the return type of the method to:
```rust
pub fn get_substitution_key(&self) -> Result<Vec<&str>, &'static str>
```
because of cases like `FOO=$BAR$BAZ` -> `["BAR", "BAZ"]`
and because there could be an errors while parsing keys.

UPD: final function signature is:
```rust
pub fn get_substitution_key(&self) -> Vec<&str>
```
Function should stop parsing on error and return parsed keys: `FOO=$BAR ${BAZ $BAM` -> `["BAR"]`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
