### PR TITLE
Print message if there are no input files (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Print a message when there are no input files [#392](https://github.com/dotenv-linter/dotenv-linter/pull/392) ([@jodli](https://github.com/jodli))
 - Add a GitHub Action to compare benchmarks [#378](https://github.com/dotenv-linter/dotenv-linter/pull/378) ([@mgrachev](https://github.com/mgrachev))
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 

--- a/src/common/output/check.rs
+++ b/src/common/output/check.rs
@@ -16,6 +16,17 @@ impl CheckOutput {
         }
     }
 
+    /// Prints information when there is nothing to check and returns a boolean
+    pub fn is_something_to_check(&self) -> bool {
+        if self.files_count == 0 {
+            if !self.is_quiet_mode {
+                println!("Nothing to check");
+            }
+            return false;
+        }
+        true
+    }
+
     /// Prints information about a file in process
     pub fn print_processing_info(&self, file: &FileEntry) {
         if !self.is_quiet_mode {

--- a/src/common/output/check.rs
+++ b/src/common/output/check.rs
@@ -16,15 +16,11 @@ impl CheckOutput {
         }
     }
 
-    /// Prints information when there is nothing to check and returns a boolean
-    pub fn is_something_to_check(&self) -> bool {
-        if self.files_count == 0 {
-            if !self.is_quiet_mode {
-                println!("Nothing to check");
-            }
-            return false;
+    /// Prints a message that there is nothing to check
+    pub fn print_nothing_to_check(&self) {
+        if !self.is_quiet_mode {
+            println!("Nothing to check");
         }
-        true
     }
 
     /// Prints information about a file in process

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@ pub fn check(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<usize, Bo
     let lines_map = get_lines(args, current_dir);
     let output = CheckOutput::new(args.is_present("quiet"), lines_map.len());
 
-    if !output.is_something_to_check() {
+    if lines_map.is_empty() {
+        output.print_nothing_to_check();
         return Ok(0);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@ use std::rc::Rc;
 
 pub fn check(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<usize, Box<dyn Error>> {
     let lines_map = get_lines(args, current_dir);
+    let output = CheckOutput::new(args.is_present("quiet"), lines_map.len());
 
-    // Nothing to check
-    if lines_map.is_empty() {
+    if !output.is_something_to_check() {
         return Ok(0);
     }
 
@@ -27,7 +27,6 @@ pub fn check(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<usize, Bo
         skip_checks = skip.collect();
     }
 
-    let output = CheckOutput::new(args.is_present("quiet"), lines_map.len());
     let warnings_count =
         lines_map
             .into_iter()

--- a/tests/options/exclude.rs
+++ b/tests/options/exclude.rs
@@ -5,7 +5,10 @@ fn exclude_one_file() {
     let test_dir = TestDir::new();
     let testfile = test_dir.create_testfile(".env", " FOO=\n");
 
-    let expected_output = check_output(&[]);
+    let expected_output = String::from(
+        r#"Nothing to check
+"#,
+    );
 
     test_dir.test_command_success_with_args(&["--exclude", testfile.as_str()], expected_output);
 }
@@ -16,7 +19,10 @@ fn exclude_two_files() {
     let testfile_1 = test_dir.create_testfile(".env", " FOO=\n");
     let testfile_2 = test_dir.create_testfile(".local.env", " BAR=\n");
 
-    let expected_output = check_output(&[]);
+    let expected_output = String::from(
+        r#"Nothing to check
+"#,
+    );
 
     test_dir.test_command_success_with_args(
         &["-e", testfile_1.as_str(), "-e", testfile_2.as_str()],

--- a/tests/output/check.rs
+++ b/tests/output/check.rs
@@ -108,6 +108,18 @@ No problems found
 }
 
 #[test]
+fn no_files() {
+    let test_dir = TestDir::new();
+
+    let expected_output = String::from(
+        r#"Nothing to check
+"#,
+    );
+
+    test_dir.test_command_success(expected_output);
+}
+
+#[test]
 fn quiet() {
     let test_dir = TestDir::new();
     test_dir.create_testfile(".env", "abc=DEF\n\nF=BAR\nB=bbb\n");
@@ -127,6 +139,16 @@ fn quiet_no_problems() {
 
     let args = &["--quiet"];
     let expected_output = "";
+
+    test_dir.test_command_success_with_args(args, expected_output);
+}
+
+#[test]
+fn quiet_no_files() {
+    let test_dir = TestDir::new();
+
+    let args = &["--quiet"];
+    let expected_output = String::from("");
 
     test_dir.test_command_success_with_args(args, expected_output);
 }


### PR DESCRIPTION
This implements #384 

I had to change the exclude tests as well, as they just excluded all loaded files... :)

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
