### PR TITLE
Use Rc for LineEntry to reduce memory consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
-- Use Rc<LineEntry> internally to reduce memory consumption [#388](https://github.com/dotenv-linter/dotenv-linter/issues/388) ([@Tom01098](https://github.com/Tom01098))
+- Use Rc<FileEntry> internally to reduce memory consumption [#388](https://github.com/dotenv-linter/dotenv-linter/issues/388) ([@Tom01098](https://github.com/Tom01098))
 - Use [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) to run clippy [#375](https://github.com/dotenv-linter/dotenv-linter/pull/375) ([@mgrachev](https://github.com/mgrachev))
 - Remove `Result` from the return type [#374](https://github.com/dotenv-linter/dotenv-linter/pull/374) ([@DDtKey](https://github.com/DDtKey))
 - Add `.bak` extension to backup files and don't lint backup files [#367](https://github.com/dotenv-linter/dotenv-linter/pull/367) ([@mstruebing](https://github.com/mstruebing))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
-- Use Rc<FileEntry> internally to reduce memory consumption [#388](https://github.com/dotenv-linter/dotenv-linter/issues/388) ([@Tom01098](https://github.com/Tom01098))
+- Use Rc<FileEntry> internally to reduce memory consumption [#393](https://github.com/dotenv-linter/dotenv-linter/issues/393) ([@Tom01098](https://github.com/Tom01098))
 - Use [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) to run clippy [#375](https://github.com/dotenv-linter/dotenv-linter/pull/375) ([@mgrachev](https://github.com/mgrachev))
 - Remove `Result` from the return type [#374](https://github.com/dotenv-linter/dotenv-linter/pull/374) ([@DDtKey](https://github.com/DDtKey))
 - Add `.bak` extension to backup files and don't lint backup files [#367](https://github.com/dotenv-linter/dotenv-linter/pull/367) ([@mstruebing](https://github.com/mstruebing))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Use Rc<LineEntry> internally to reduce memory consumption [#388](https://github.com/dotenv-linter/dotenv-linter/issues/388) ([@Tom01098](https://github.com/Tom01098))
 - Use [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) to run clippy [#375](https://github.com/dotenv-linter/dotenv-linter/pull/375) ([@mgrachev](https://github.com/mgrachev))
 - Remove `Result` from the return type [#374](https://github.com/dotenv-linter/dotenv-linter/pull/374) ([@DDtKey](https://github.com/DDtKey))
 - Add `.bak` extension to backup files and don't lint backup files [#367](https://github.com/dotenv-linter/dotenv-linter/pull/367) ([@mstruebing](https://github.com/mstruebing))

--- a/src/common.rs
+++ b/src/common.rs
@@ -36,7 +36,6 @@ pub(crate) mod tests {
                 total_lines,
             }),
             String::from("\n"),
-            false,
         )
     }
 
@@ -50,7 +49,6 @@ pub(crate) mod tests {
                 total_lines,
             }),
             String::from(raw_string),
-            false,
         )
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -24,33 +24,34 @@ pub fn remove_invalid_leading_chars(string: &str) -> &str {
 pub(crate) mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::rc::Rc;
 
     #[allow(dead_code)]
     pub fn blank_line_entry(number: usize, total_lines: usize) -> LineEntry {
-        LineEntry {
+        LineEntry::new(
             number,
-            file: FileEntry {
+            Rc::new(FileEntry {
                 path: PathBuf::from(".env"),
                 file_name: ".env".to_string(),
                 total_lines,
-            },
-            raw_string: String::from("\n"),
-            is_deleted: false,
-        }
+            }),
+            String::from("\n"),
+            false,
+        )
     }
 
     #[allow(dead_code)]
     pub fn line_entry(number: usize, total_lines: usize, raw_string: &str) -> LineEntry {
-        LineEntry {
+        LineEntry::new(
             number,
-            file: FileEntry {
+            Rc::new(FileEntry {
                 path: PathBuf::from(".env"),
                 file_name: ".env".to_string(),
                 total_lines,
-            },
-            raw_string: String::from(raw_string),
-            is_deleted: false,
-        }
+            }),
+            String::from(raw_string),
+            false,
+        )
     }
 
     #[test]

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -1,10 +1,13 @@
-use crate::common::*;
+use std::rc::Rc;
+
 use comment::Comment;
+
+use crate::common::*;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LineEntry {
     pub number: usize,
-    pub file: FileEntry,
+    pub file: Rc<FileEntry>,
     pub raw_string: String,
 
     /// Used in ExtraBlankLineFixer
@@ -12,6 +15,10 @@ pub struct LineEntry {
 }
 
 impl LineEntry {
+    pub fn new(number: usize, file: Rc<FileEntry>, raw_string: String, is_deleted: bool) -> Self {
+        LineEntry { number, file, raw_string, is_deleted }
+    }
+
     pub fn is_empty_or_comment(&self) -> bool {
         self.is_empty() || self.is_comment()
     }
@@ -111,6 +118,7 @@ mod tests {
 
     mod get_key {
         use super::*;
+
         #[test]
         fn empty_line_test() {
             let input = line_entry(1, 1, "");

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -15,12 +15,12 @@ pub struct LineEntry {
 }
 
 impl LineEntry {
-    pub fn new(number: usize, file: Rc<FileEntry>, raw_string: String, is_deleted: bool) -> Self {
+    pub fn new(number: usize, file: Rc<FileEntry>, raw_string: String) -> Self {
         LineEntry {
             number,
             file,
             raw_string,
-            is_deleted,
+            is_deleted: false,
         }
     }
 

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -16,7 +16,12 @@ pub struct LineEntry {
 
 impl LineEntry {
     pub fn new(number: usize, file: Rc<FileEntry>, raw_string: String, is_deleted: bool) -> Self {
-        LineEntry { number, file, raw_string, is_deleted }
+        LineEntry {
+            number,
+            file,
+            raw_string,
+            is_deleted,
+        }
     }
 
     pub fn is_empty_or_comment(&self) -> bool {

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -30,12 +30,7 @@ impl Fix for EndingBlankLineFixer<'_> {
         }
 
         let file = lines.first()?.file.clone();
-        lines.push(LineEntry::new(
-            lines.len() + 1,
-            file,
-            LF.to_string(),
-            false,
-        ));
+        lines.push(LineEntry::new(lines.len() + 1, file, LF.to_string(), false));
 
         Some(1)
     }

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -30,12 +30,12 @@ impl Fix for EndingBlankLineFixer<'_> {
         }
 
         let file = lines.first()?.file.clone();
-        lines.push(LineEntry {
-            number: lines.len() + 1,
+        lines.push(LineEntry::new(
+            lines.len() + 1,
             file,
-            raw_string: LF.to_string(),
-            is_deleted: false,
-        });
+            LF.to_string(),
+            false,
+        ));
 
         Some(1)
     }

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -30,7 +30,7 @@ impl Fix for EndingBlankLineFixer<'_> {
         }
 
         let file = lines.first()?.file.clone();
-        lines.push(LineEntry::new(lines.len() + 1, file, LF.to_string(), false));
+        lines.push(LineEntry::new(lines.len() + 1, file, LF.to_string()));
 
         Some(1)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,6 @@ fn get_line_entries(fe: &FileEntry, lines: Vec<String>) -> Vec<LineEntry> {
     lines
         .into_iter()
         .enumerate()
-        .map(|(index, line)| LineEntry::new(index + 1, fe.clone(), line, false))
+        .map(|(index, line)| LineEntry::new(index + 1, fe.clone(), line))
         .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,11 +226,6 @@ fn get_line_entries(fe: &FileEntry, lines: Vec<String>) -> Vec<LineEntry> {
     lines
         .into_iter()
         .enumerate()
-        .map(|(index, line)| LineEntry::new(
-            index + 1,
-            fe.clone(),
-            line,
-            false,
-        ))
+        .map(|(index, line)| LineEntry::new(index + 1, fe.clone(), line, false))
         .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod fs_utils;
 
 pub use checks::available_check_names;
 use common::CompareWarning;
+use std::rc::Rc;
 
 pub fn check(args: &clap::ArgMatches, current_dir: &PathBuf) -> Result<usize, Box<dyn Error>> {
     let lines_map = get_lines(args, current_dir);
@@ -221,14 +222,15 @@ fn get_file_paths(
 }
 
 fn get_line_entries(fe: &FileEntry, lines: Vec<String>) -> Vec<LineEntry> {
+    let fe = Rc::new(fe.clone());
     lines
         .into_iter()
         .enumerate()
-        .map(|(index, line)| LineEntry {
-            number: index + 1,
-            file: fe.clone(),
-            raw_string: line,
-            is_deleted: false,
-        })
+        .map(|(index, line)| LineEntry::new(
+            index + 1,
+            fe.clone(),
+            line,
+            false,
+        ))
         .collect()
 }


### PR DESCRIPTION
Closes #388.

#### ✔ Checklist:
- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
