### PR TITLE
Allow unordered keys for substitution variables (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Allow unordered keys for substitution variables [#401](https://github.com/dotenv-linter/dotenv-linter/pull/401) ([@Ru5ty0ne](https://github.com/Ru5ty0ne))
 - Replace String on Into<String> for all TestDir methods [#397](https://github.com/dotenv-linter/dotenv-linter/pull/397) ([@ebobrow](https://github.com/ebobrow))
 - Use Rc<FileEntry> internally to reduce memory consumption [#393](https://github.com/dotenv-linter/dotenv-linter/issues/393) ([@Tom01098](https://github.com/Tom01098))
 - Use [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) to run clippy [#375](https://github.com/dotenv-linter/dotenv-linter/pull/375) ([@mgrachev](https://github.com/mgrachev))

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -27,14 +27,13 @@ impl Default for UnorderedKeyChecker<'_> {
 
 impl Check for UnorderedKeyChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
-        let sub_keys = line.get_substitution_keys();
-        let substitution_check = !sub_keys.is_empty()
-            && sub_keys
-                .iter()
-                .all(|&sub_key| self.keys.contains(&sub_key.to_string()));
+        let has_substitution_in_group = line
+            .get_substitution_keys()
+            .iter()
+            .any(|k| self.keys.iter().any(|key| key == k));
 
         // Support of grouping variables through blank lines and control comments
-        if line.is_empty() || line.get_control_comment().is_some() || substitution_check {
+        if line.is_empty() || line.get_control_comment().is_some() || has_substitution_in_group {
             self.keys.clear();
             return None;
         }

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -222,4 +222,70 @@ mod tests {
 
         run_unordered_tests(asserts);
     }
+
+    #[test]
+    fn three_ordered_groups_with_two_unordered_substitution_keys_that_have_multiple_values_test() {
+        let asserts = vec![
+            (line_entry(1, 3, "BBB=XYZ"), None),
+            (line_entry(2, 3, "HHH=VAL"), None),
+            (line_entry(3, 3, "ZZZ=VALUE"), None),
+            (
+                line_entry(4, 3, "CCC=$NNN$HHH # Unordered, CCC uses HHH"),
+                None,
+            ),
+            (line_entry(5, 3, "BAR=FOOD"), None),
+            (line_entry(6, 3, "BIG=FOOT"), None),
+            (line_entry(7, 3, "WWW=$XYZ$TTT"), None),
+            (line_entry(8, 3, "YYY=FOO"), None),
+            (
+                line_entry(9, 3, "BOO=$BAR$BBB$ZZZ # Unordered, BOO uses BAR"),
+                None,
+            ),
+            (line_entry(10, 3, "TTT=BIG"), None),
+            (line_entry(11, 3, "XYZ=G"), None),
+        ];
+
+        run_unordered_tests(asserts);
+    }
+
+    #[test]
+    fn two_unordered_groups_before_and_after_unordered_substitution_keys_test() {
+        let asserts = vec![
+            (line_entry(1, 3, "HHH=VAL"), None),
+            (line_entry(2, 3, "ZZZ=VALUE"), None),
+            (
+                line_entry(3, 3, "BBB=$XYZ"),
+                Some(Warning::new(
+                    line_entry(3, 3, "BBB=$XYZ"),
+                    "UnorderedKey",
+                    "The BBB key should go before the HHH key",
+                )),
+            ),
+            (line_entry(4, 3, "CCC=$HHH # Unordered, CCC uses HHH"), None),
+            (line_entry(5, 3, "TTT=BIG"), None),
+            (line_entry(6, 3, "XYZ=G"), None),
+            (
+                line_entry(7, 3, "GGG=JJJ"),
+                Some(Warning::new(
+                    line_entry(7, 3, "GGG=JJJ"),
+                    "UnorderedKey",
+                    "The GGG key should go before the TTT key",
+                )),
+            ),
+            (
+                line_entry(8, 3, "AAA=$ZZZ"),
+                Some(Warning::new(
+                    line_entry(8, 3, "AAA=$ZZZ"),
+                    "UnorderedKey",
+                    "The AAA key should go before the GGG key",
+                )),
+            ),
+            (
+                line_entry(9, 3, "MMM=$GGG$ZZZ # Unordered, MMM uses GGG"),
+                None,
+            ),
+        ];
+
+        run_unordered_tests(asserts);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Solves [#382](https://github.com/dotenv-linter/dotenv-linter/issues/382)

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
