### PR TITLE
Get rid of String::from when creating LineEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add benchmark for the check function [#376](https://github.com/dotenv-linter/dotenv-linter/pull/376) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Replace `String` with `Into<String>` in `LineEntry::new`  [#404](https://github.com/dotenv-linter/dotenv-linter/pull/404) ([@miDeb](https://github.com/miDeb))
 - Replace String on Into<String> for all TestDir methods [#397](https://github.com/dotenv-linter/dotenv-linter/pull/397) ([@ebobrow](https://github.com/ebobrow))
 - Use Rc<FileEntry> internally to reduce memory consumption [#393](https://github.com/dotenv-linter/dotenv-linter/pull/393) ([@Tom01098](https://github.com/Tom01098))
 - Use [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) to run clippy [#375](https://github.com/dotenv-linter/dotenv-linter/pull/375) ([@mgrachev](https://github.com/mgrachev))

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,7 +35,7 @@ pub(crate) mod tests {
                 file_name: ".env".to_string(),
                 total_lines,
             }),
-            String::from("\n"),
+            "\n",
         )
     }
 
@@ -48,7 +48,7 @@ pub(crate) mod tests {
                 file_name: ".env".to_string(),
                 total_lines,
             }),
-            String::from(raw_string),
+            raw_string,
         )
     }
 

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -15,11 +15,14 @@ pub struct LineEntry {
 }
 
 impl LineEntry {
-    pub fn new(number: usize, file: Rc<FileEntry>, raw_string: String) -> Self {
+    pub fn new<T>(number: usize, file: Rc<FileEntry>, raw_string: T) -> Self
+    where
+        T: Into<String>,
+    {
         LineEntry {
             number,
             file,
-            raw_string,
+            raw_string: raw_string.into(),
             is_deleted: false,
         }
     }

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -30,7 +30,7 @@ impl Fix for EndingBlankLineFixer<'_> {
         }
 
         let file = lines.first()?.file.clone();
-        lines.push(LineEntry::new(lines.len() + 1, file, LF.to_string()));
+        lines.push(LineEntry::new(lines.len() + 1, file, LF));
 
         Some(1)
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Closes https://github.com/dotenv-linter/dotenv-linter/issues/403.
<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

