### PR TITLE
Check if the amount of predicted checks match the amount of checks done, print warning if not.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Affirm that the amount of predicted checks match the amount of checks done, print warning they don't [#415](https://github.com/dotenv-linter/dotenv-linter/pull/415) ([@marcel-baur](https://github.com/marcel-baur))
 - Print a message "Nothing to compare" [#398](https://github.com/dotenv-linter/dotenv-linter/pull/398) ([@jakecorrenti](https://github.com/jakecorrenti))
 - Add action-hadolint [#400](https://github.com/dotenv-linter/dotenv-linter/pull/400) ([@iovanom](https://github.com/iovanom))
 - Add method to get substitution keys to LineEntry [#391](https://github.com/dotenv-linter/dotenv-linter/pull/391) ([@zotho](https://github.com/zotho))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
-- Affirm that the amount of predicted checks match the amount of checks done, print warning they don't [#415](https://github.com/dotenv-linter/dotenv-linter/pull/415) ([@marcel-baur](https://github.com/marcel-baur))
+- Print a message if the amount of checks doesn't match the amount of fixes [#415](https://github.com/dotenv-linter/dotenv-linter/pull/415) ([@marcel-baur](https://github.com/marcel-baur)))
 - Print a message "Nothing to compare" [#398](https://github.com/dotenv-linter/dotenv-linter/pull/398) ([@jakecorrenti](https://github.com/jakecorrenti))
 - Add action-hadolint [#400](https://github.com/dotenv-linter/dotenv-linter/pull/400) ([@iovanom](https://github.com/iovanom))
 - Add method to get substitution keys to LineEntry [#391](https://github.com/dotenv-linter/dotenv-linter/pull/391) ([@zotho](https://github.com/zotho))

--- a/src/common/output/fix.rs
+++ b/src/common/output/fix.rs
@@ -1,4 +1,5 @@
 use crate::common::{FileEntry, Warning};
+use colored::*;
 use std::ffi::OsString;
 
 /// Prefix for the backup output
@@ -70,6 +71,6 @@ impl FixOutput {
             return;
         }
 
-        println!("Could not fix all warnings!");
+        println!("{}", "Could not fix all warnings".red().bold());
     }
 }

--- a/src/common/output/fix.rs
+++ b/src/common/output/fix.rs
@@ -63,4 +63,13 @@ impl FixOutput {
 
         println!("Nothing to fix");
     }
+
+    /// Prints not all warnings fixed message
+    pub fn print_not_all_warnings_fixes(&self) {
+        if self.is_quiet_mode {
+            return;
+        }
+
+        println!("Could not fix all warnings!");
+    }
 }

--- a/src/common/output/fix.rs
+++ b/src/common/output/fix.rs
@@ -66,7 +66,7 @@ impl FixOutput {
     }
 
     /// Prints not all warnings fixed message
-    pub fn print_not_all_warnings_fixes(&self) {
+    pub fn print_not_all_warnings_fixed(&self) {
         if self.is_quiet_mode {
             return;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
         }
         let fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
         if fixes_done != result.len() {
-            output.print_not_all_warnings_fixes();
+            output.print_not_all_warnings_fixed();
         }
         if fixes_done > 0 {
             let should_backup = !args.is_present("no-backup");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,11 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
         let mut result = checks::run(&lines, &skip_checks);
         let expected_fixes = result.len();
         let fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
+        // Compare amount of fixes done to amount of expected fixes. Print warning if they differ.
         if fixes_done < expected_fixes {
             output.print_not_all_warnings_fixes();
         }
-        // run fixers & write results to file
+        // write results to file
         if !result.is_empty() && fixes_done > 0 {
             let should_backup = !args.is_present("no-backup");
             // create backup copy unless user specifies not to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,17 +68,14 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
 
         let mut lines = get_line_entries(&fe, strings);
         let mut result = checks::run(&lines, &skip_checks);
-        let expected_fixes = result.len();
-        let mut fixes_done = 0;
-        if !result.is_empty() {
-            fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
+        if result.is_empty() {
+            continue;
         }
-        // Compare amount of fixes done to amount of expected fixes. Print warning if they differ.
-        if fixes_done < expected_fixes {
+        let fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
+        if fixes_done != result.len() {
             output.print_not_all_warnings_fixes();
         }
-        // write results to file
-        if !result.is_empty() && fixes_done > 0 {
+        if fixes_done > 0 {
             let should_backup = !args.is_present("no-backup");
             // create backup copy unless user specifies not to
             if should_backup {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,13 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
 
         let mut lines = get_line_entries(&fe, strings);
         let mut result = checks::run(&lines, &skip_checks);
-
+        let expected_fixes = result.len();
+        let fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
+        if fixes_done < expected_fixes {
+            print!("Could not fix all warnings!");
+        }
         // run fixers & write results to file
-        if !result.is_empty() && fixes::run(&mut result, &mut lines, &skip_checks) > 0 {
+        if !result.is_empty() && fixes_done > 0 {
             let should_backup = !args.is_present("no-backup");
             // create backup copy unless user specifies not to
             if should_backup {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,10 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
         let mut lines = get_line_entries(&fe, strings);
         let mut result = checks::run(&lines, &skip_checks);
         let expected_fixes = result.len();
-        let fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
+        let mut fixes_done = 0;
+        if !result.is_empty() {
+            fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
+        }
         // Compare amount of fixes done to amount of expected fixes. Print warning if they differ.
         if fixes_done < expected_fixes {
             output.print_not_all_warnings_fixes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
         let expected_fixes = result.len();
         let fixes_done = fixes::run(&mut result, &mut lines, &skip_checks);
         if fixes_done < expected_fixes {
-            print!("Could not fix all warnings!");
+            output.print_not_all_warnings_fixes();
         }
         // run fixers & write results to file
         if !result.is_empty() && fixes_done > 0 {


### PR DESCRIPTION
Regards (#409). 
Are there any cases where this issue occurs?  If so, I could add a test case. 
#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);


