### PR TITLE
test: keep LF line endings so tests pass on Windows

### DIFF
--- a/tests/fixes/fixtures/.gitattributes
+++ b/tests/fixes/fixtures/.gitattributes
@@ -1,0 +1,2 @@
+*.env text eol=lf
+*.env.golden text eol=lf


### PR DESCRIPTION
Git on Windows can automatically convert line endings from LF to CRLF when you clone a repo. This change ensures that the LF line endings are kept for .env and .env.golden files in the /tests/fixes/fixtures/ directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
