### PR TITLE
Refactor Check unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Refactor check unit tests [#421](https://github.com/dotenv-linter/dotenv-linter/pull/421) [@mc1098](https://github.com/mc1098)
 - Add missing integration tests [#420](https://github.com/dotenv-linter/dotenv-linter/pull/420) ([@gosolivs](https://github.com/gosolivs))
 - Add checker: Substitution Key [#414](https://github.com/dotenv-linter/dotenv-linter/pull/414) ([@de-sh](https://github.com/de-sh))
 - Print a message if the amount of checks doesn't match the amount of fixes [#415](https://github.com/dotenv-linter/dotenv-linter/pull/415) ([@marcel-baur](https://github.com/marcel-baur)))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -14,7 +14,7 @@ mod trailing_whitespace;
 mod unordered_key;
 
 // This trait is used for checks which needs to know of only a single line
-trait Check {
+pub trait Check {
     fn run(&mut self, line: &LineEntry) -> Option<Warning>;
     fn name(&self) -> &str;
     fn skip_comments(&self) -> bool {

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -44,94 +44,32 @@ impl Check for DuplicatedKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    fn run_duplicated_tests(asserts: Vec<(LineEntry, Option<Warning>)>) {
-        let mut checker = DuplicatedKeyChecker::default();
-
-        for assert in asserts {
-            let (input, output) = assert;
-            assert_eq!(checker.run(&input), output);
+    check_tester!{
+        DuplicatedKeyChecker;
+        with_one_duplicated_key_test => {
+            "FOO=BAR" => None,
+            "FOO=BAR" => Some("The FOO key is duplicated"),
+        },
+        with_two_unique_keys_test => {
+            "FOO=BAR" => None,
+            "BAR=FOO" => None,
+        },
+        with_two_unique_keys_case_sensitive_test => {
+            "FOO=BAR" => None,
+            "Foo=FOO" => None,
+        },
+        with_two_duplicated_keys_test => {
+            "FOO=BAR" => None,
+            "FOO=BAR" => Some("The FOO key is duplicated"),
+            "BAR=FOO" => None,
+            "BAR=FOO" => Some("The BAR key is duplicated"),
+        },
+        one_duplicated_and_one_unique_key_test => {
+            "FOO=BAR" => None,
+            "FOO=BAR" => Some("The FOO key is duplicated"),
+            "BAR=FOO" => None,
         }
-    }
-
-    #[test]
-    fn with_one_duplicated_key_test() {
-        let asserts = vec![
-            (line_entry(1, 2, "FOO=BAR"), None),
-            (
-                line_entry(2, 2, "FOO=BAR"),
-                Some(Warning::new(
-                    line_entry(2, 2, "FOO=BAR"),
-                    "DuplicatedKey",
-                    "The FOO key is duplicated",
-                )),
-            ),
-        ];
-
-        run_duplicated_tests(asserts);
-    }
-
-    #[test]
-    fn with_two_unique_keys_test() {
-        let asserts = vec![
-            (line_entry(1, 2, "FOO=BAR"), None),
-            (line_entry(2, 2, "BAR=FOO"), None),
-        ];
-
-        run_duplicated_tests(asserts);
-    }
-    #[test]
-    fn with_two_unique_keys_case_sensitive_test() {
-        let asserts = vec![
-            (line_entry(1, 2, "FOO=BAR"), None),
-            (line_entry(2, 2, "Foo=FOO"), None),
-        ];
-
-        run_duplicated_tests(asserts);
-    }
-
-    #[test]
-    fn with_two_duplicated_keys_test() {
-        let asserts = vec![
-            (line_entry(1, 4, "FOO=BAR"), None),
-            (
-                line_entry(2, 4, "FOO=BAR"),
-                Some(Warning::new(
-                    line_entry(2, 4, "FOO=BAR"),
-                    "DuplicatedKey",
-                    "The FOO key is duplicated",
-                )),
-            ),
-            (line_entry(3, 4, "BAR=FOO"), None),
-            (
-                line_entry(4, 4, "BAR=FOO"),
-                Some(Warning::new(
-                    line_entry(4, 4, "BAR=FOO"),
-                    "DuplicatedKey",
-                    "The BAR key is duplicated",
-                )),
-            ),
-        ];
-
-        run_duplicated_tests(asserts);
-    }
-
-    #[test]
-    fn one_duplicated_and_one_unique_key_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "FOO=BAR"), None),
-            (
-                line_entry(2, 3, "FOO=BAR"),
-                Some(Warning::new(
-                    line_entry(2, 3, "FOO=BAR"),
-                    "DuplicatedKey",
-                    "The FOO key is duplicated",
-                )),
-            ),
-            (line_entry(3, 3, "BAR=FOO"), None),
-        ];
-
-        run_duplicated_tests(asserts);
     }
 }

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -44,32 +44,57 @@ impl Check for DuplicatedKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        DuplicatedKeyChecker;
-        with_one_duplicated_key_test => {
-            "FOO=BAR" => None,
-            "FOO=BAR" => Some("The FOO key is duplicated"),
-        },
-        with_two_unique_keys_test => {
-            "FOO=BAR" => None,
-            "BAR=FOO" => None,
-        },
-        with_two_unique_keys_case_sensitive_test => {
-            "FOO=BAR" => None,
-            "Foo=FOO" => None,
-        },
-        with_two_duplicated_keys_test => {
-            "FOO=BAR" => None,
-            "FOO=BAR" => Some("The FOO key is duplicated"),
-            "BAR=FOO" => None,
-            "BAR=FOO" => Some("The BAR key is duplicated"),
-        },
-        one_duplicated_and_one_unique_key_test => {
-            "FOO=BAR" => None,
-            "FOO=BAR" => Some("The FOO key is duplicated"),
-            "BAR=FOO" => None,
-        }
+    #[test]
+    fn with_one_duplicated_key_test() {
+        check_test(
+            &mut DuplicatedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("FOO=BAR", Some("The FOO key is duplicated")),
+            ],
+        );
+    }
+
+    #[test]
+    fn with_two_unique_keys_test() {
+        check_test(
+            &mut DuplicatedKeyChecker::default(),
+            [("FOO=BAR", None), ("BAR=FOO", None)],
+        );
+    }
+
+    #[test]
+    fn with_two_unique_keys_case_sensitive_test() {
+        check_test(
+            &mut DuplicatedKeyChecker::default(),
+            [("FOO=BAR", None), ("Foo=FOO", None)],
+        );
+    }
+
+    #[test]
+    fn with_two_duplicated_keys_test() {
+        check_test(
+            &mut DuplicatedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("FOO=BAR", Some("The FOO key is duplicated")),
+                ("BAR=FOO", None),
+                ("BAR=FOO", Some("The BAR key is duplicated")),
+            ],
+        );
+    }
+
+    #[test]
+    fn one_duplicated_and_one_unique_key_test() {
+        check_test(
+            &mut DuplicatedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("FOO=BAR", Some("The FOO key is duplicated")),
+                ("BAR=FOO", None),
+            ],
+        );
     }
 }

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -46,7 +46,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-    check_tester!{
+    check_tester! {
         DuplicatedKeyChecker;
         with_one_duplicated_key_test => {
             "FOO=BAR" => None,

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -42,18 +42,23 @@ impl Check for EndingBlankLineChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        EndingBlankLineChecker;
-        blank_line => {
-            "\n" => None,
-        },
-        blank_line_rn => {
-            "\r\n" => None,
-        },
-        no_blank_line => {
-            "a" => Some("No blank line at the end of the file"),
-        }
+    #[test]
+    fn blank_line() {
+        check_test(&mut EndingBlankLineChecker::default(), [("\n", None)]);
+    }
+
+    #[test]
+    fn blank_line_rn() {
+        check_test(&mut EndingBlankLineChecker::default(), [("\r\n", None)]);
+    }
+
+    #[test]
+    fn no_blank_line() {
+        check_test(
+            &mut EndingBlankLineChecker::default(),
+            [("a", Some("No blank line at the end of the file"))],
+        );
     }
 }

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-    check_tester!{
+    check_tester! {
         EndingBlankLineChecker;
         blank_line => {
             "\n" => None,

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -42,33 +42,18 @@ impl Check for EndingBlankLineChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    #[test]
-    fn blank_line() {
-        let mut checker = EndingBlankLineChecker::default();
-        let line = line_entry(1, 1, "\n");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn blank_line_rn() {
-        let mut checker = EndingBlankLineChecker::default();
-        let line = line_entry(1, 1, "\r\n");
-
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn no_blank_line() {
-        let mut checker = EndingBlankLineChecker::default();
-        let line = line_entry(1, 1, "a");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "EndingBlankLine",
-            "No blank line at the end of the file",
-        ));
-
-        assert_eq!(expected, checker.run(&line));
+    check_tester!{
+        EndingBlankLineChecker;
+        blank_line => {
+            "\n" => None,
+        },
+        blank_line_rn => {
+            "\r\n" => None,
+        },
+        no_blank_line => {
+            "a" => Some("No blank line at the end of the file"),
+        }
     }
 }

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -50,57 +50,31 @@ impl Check for ExtraBlankLineChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    fn run_asserts(asserts: Vec<(&str, Option<&str>)>) {
-        let mut checker = ExtraBlankLineChecker::default();
-
-        for (i, assert) in asserts.iter().enumerate() {
-            let (content, message) = *assert;
-            let line = line_entry(i + 1, asserts.len(), content);
-
-            let expected = message.map(|msg| Warning::new(line.clone(), "ExtraBlankLine", msg));
-
-            assert_eq!(checker.run(&line), expected);
+    check_tester!{
+        ExtraBlankLineChecker;
+        no_blank_lines => {
+            "A=B" => None,
+            "C=D" => None,
+        },
+        single_blank_line => {
+            "A=B"   => None,
+            ""      => None,
+            "C=D"   => None,
+        },
+        two_blank_lines => {
+            "A=B"   => None,
+            ""      => None,
+            ""      => Some("Extra blank line detected"),
+            "C=D"   => None,
+        },
+        three_blank_lines => {
+            "A=B"   => None,
+            ""      => None,
+            ""      => Some("Extra blank line detected"),
+            ""      => Some("Extra blank line detected"),
+            "C=D"   => None,
         }
-    }
-
-    #[test]
-    fn no_blank_lines() {
-        let asserts = vec![("A=B", None), ("C=D", None)];
-
-        run_asserts(asserts);
-    }
-
-    #[test]
-    fn single_blank_line() {
-        let asserts = vec![("A=B", None), ("", None), ("C=D", None)];
-
-        run_asserts(asserts);
-    }
-
-    #[test]
-    fn two_blank_lines() {
-        let asserts = vec![
-            ("A=B", None),
-            ("", None),
-            ("", Some("Extra blank line detected")),
-            ("C=D", None),
-        ];
-
-        run_asserts(asserts);
-    }
-
-    #[test]
-    fn three_blank_lines() {
-        let asserts = vec![
-            ("A=B", None),
-            ("", None),
-            ("", Some("Extra blank line detected")),
-            ("", Some("Extra blank line detected")),
-            ("C=D", None),
-        ];
-
-        run_asserts(asserts);
     }
 }

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -50,31 +50,48 @@ impl Check for ExtraBlankLineChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        ExtraBlankLineChecker;
-        no_blank_lines => {
-            "A=B" => None,
-            "C=D" => None,
-        },
-        single_blank_line => {
-            "A=B"   => None,
-            ""      => None,
-            "C=D"   => None,
-        },
-        two_blank_lines => {
-            "A=B"   => None,
-            ""      => None,
-            ""      => Some("Extra blank line detected"),
-            "C=D"   => None,
-        },
-        three_blank_lines => {
-            "A=B"   => None,
-            ""      => None,
-            ""      => Some("Extra blank line detected"),
-            ""      => Some("Extra blank line detected"),
-            "C=D"   => None,
-        }
+    #[test]
+    fn no_blank_lines() {
+        check_test(
+            &mut ExtraBlankLineChecker::default(),
+            [("A=B", None), ("C=D", None)],
+        );
+    }
+
+    #[test]
+    fn single_blank_line() {
+        check_test(
+            &mut ExtraBlankLineChecker::default(),
+            [("A=B", None), ("", None), ("C=D", None)],
+        );
+    }
+
+    #[test]
+    fn two_blank_lines() {
+        check_test(
+            &mut ExtraBlankLineChecker::default(),
+            [
+                ("A=B", None),
+                ("", None),
+                ("", Some("Extra blank line detected")),
+                ("C=D", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn three_blank_lines() {
+        check_test(
+            &mut ExtraBlankLineChecker::default(),
+            [
+                ("A=B", None),
+                ("", None),
+                ("", Some("Extra blank line detected")),
+                ("", Some("Extra blank line detected")),
+                ("C=D", None),
+            ],
+        );
     }
 }

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-    check_tester!{
+    check_tester! {
         ExtraBlankLineChecker;
         no_blank_lines => {
             "A=B" => None,

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -50,7 +50,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-    check_tester!{
+    check_tester! {
         IncorrectDelimiterChecker;
         working_run => {
             "FOO_BAR=FOOBAR" => None,
@@ -91,5 +91,4 @@ mod tests {
             "F=BAR" => None,
         }
     }
-
 }

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -48,120 +48,48 @@ impl Check for IncorrectDelimiterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    #[test]
-    fn working_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "FOO_BAR=FOOBAR");
-        assert_eq!(None, checker.run(&line));
+    check_tester!{
+        IncorrectDelimiterChecker;
+        working_run => {
+            "FOO_BAR=FOOBAR" => None,
+        },
+        working_with_digits_run => {
+            "F100=BAR" => None,
+        },
+        working_with_export_run => {
+            "export FOO=BAR" => None,
+        },
+        incorrect_leading_char => {
+            // expect None because this warning should be found by LeadingCharacterChecker
+            "*FOO=BAR" => None,
+        },
+        incorrect_leading_chars_and_invalid_delimiter => {
+            "***F-OOBAR=BAZ" => Some("The ***F-OOBAR key has incorrect delimiter"),
+        },
+        incorrect_ending_delimiter => {
+            "FOO*=BAR" => Some("The FOO* key has incorrect delimiter"),
+        },
+        failing_run => {
+            "FOO-BAR=FOOBAR" => Some("The FOO-BAR key has incorrect delimiter"),
+        },
+        failing_with_whitespace_run => {
+            "FOO BAR=FOOBAR" => Some("The FOO BAR key has incorrect delimiter"),
+        },
+        unformatted_run => {
+            "FOO-BAR" => Some("The FOO-BAR key has incorrect delimiter"),
+        },
+        trailing_space_run => {
+            // has a trailing space, so SpaceCharacterChecker should catch this error
+            "FOO_BAR =FOOBAR" => None,
+        },
+        empty_run => {
+            "" => None,
+        },
+        short_run => {
+            "F=BAR" => None,
+        }
     }
 
-    #[test]
-    fn working_with_digits_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "F1OO=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_with_export_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "export FOO=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn incorrect_leading_char() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "*FOO=BAR");
-        // expect None because this warning should be found by LeadingCharacterChecker
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn incorrect_leading_chars_and_invalid_delimiter() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "***F-OOBAR=BAZ");
-
-        let expected = Some(Warning::new(
-            line.clone(),
-            "IncorrectDelimiter",
-            "The ***F-OOBAR key has incorrect delimiter",
-        ));
-
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn incorrect_ending_delimiter() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "FOO*=BAR");
-
-        let expected = Some(Warning::new(
-            line.clone(),
-            "IncorrectDelimiter",
-            "The FOO* key has incorrect delimiter",
-        ));
-
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "FOO-BAR=FOOBAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "IncorrectDelimiter",
-            "The FOO-BAR key has incorrect delimiter",
-        ));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_with_whitespace_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "FOO BAR=FOOBAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "IncorrectDelimiter",
-            "The FOO BAR key has incorrect delimiter",
-        ));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn unformatted_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "FOO-BAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "IncorrectDelimiter",
-            "The FOO-BAR key has incorrect delimiter",
-        ));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn trailing_space_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "FOO_BAR =FOOBAR");
-        // has a trailing space, so SpaceCharacterChecker should catch this error
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn empty_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn short_run() {
-        let mut checker = IncorrectDelimiterChecker::default();
-        let line = line_entry(1, 1, "F=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
 }

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -48,47 +48,104 @@ impl Check for IncorrectDelimiterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        IncorrectDelimiterChecker;
-        working_run => {
-            "FOO_BAR=FOOBAR" => None,
-        },
-        working_with_digits_run => {
-            "F100=BAR" => None,
-        },
-        working_with_export_run => {
-            "export FOO=BAR" => None,
-        },
-        incorrect_leading_char => {
-            // expect None because this warning should be found by LeadingCharacterChecker
-            "*FOO=BAR" => None,
-        },
-        incorrect_leading_chars_and_invalid_delimiter => {
-            "***F-OOBAR=BAZ" => Some("The ***F-OOBAR key has incorrect delimiter"),
-        },
-        incorrect_ending_delimiter => {
-            "FOO*=BAR" => Some("The FOO* key has incorrect delimiter"),
-        },
-        failing_run => {
-            "FOO-BAR=FOOBAR" => Some("The FOO-BAR key has incorrect delimiter"),
-        },
-        failing_with_whitespace_run => {
-            "FOO BAR=FOOBAR" => Some("The FOO BAR key has incorrect delimiter"),
-        },
-        unformatted_run => {
-            "FOO-BAR" => Some("The FOO-BAR key has incorrect delimiter"),
-        },
-        trailing_space_run => {
-            // has a trailing space, so SpaceCharacterChecker should catch this error
-            "FOO_BAR =FOOBAR" => None,
-        },
-        empty_run => {
-            "" => None,
-        },
-        short_run => {
-            "F=BAR" => None,
-        }
+    #[test]
+    fn working_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("FOO_BAR=FOOBAR", None)],
+        );
+    }
+
+    #[test]
+    fn working_with_digits_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("F100=BAR", None)],
+        );
+    }
+
+    #[test]
+    fn working_with_export_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("export FOO=BAR", None)],
+        );
+    }
+
+    #[test]
+    fn incorrect_leading_char() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("*FOO=BAR", None)],
+        );
+    }
+
+    #[test]
+    fn incorrect_leading_chars_and_invalid_delimiter() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [(
+                "***F-OOBAR=BAZ",
+                Some("The ***F-OOBAR key has incorrect delimiter"),
+            )],
+        );
+    }
+
+    #[test]
+    fn incorrect_ending_delimiter() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("FOO*=BAR", Some("The FOO* key has incorrect delimiter"))],
+        );
+    }
+
+    #[test]
+    fn failing_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [(
+                "FOO-BAR=FOOBAR",
+                Some("The FOO-BAR key has incorrect delimiter"),
+            )],
+        );
+    }
+
+    #[test]
+    fn failing_with_whitespace_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [(
+                "FOO BAR=FOOBAR",
+                Some("The FOO BAR key has incorrect delimiter"),
+            )],
+        );
+    }
+
+    #[test]
+    fn unformatted_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("FOO-BAR", Some("The FOO-BAR key has incorrect delimiter"))],
+        );
+    }
+
+    #[test]
+    fn trailing_space_run() {
+        check_test(
+            &mut IncorrectDelimiterChecker::default(),
+            [("FOO_BAR =FOOBAR", None)],
+        );
+    }
+
+    #[test]
+    fn empty_run() {
+        check_test(&mut IncorrectDelimiterChecker::default(), [("", None)]);
+    }
+
+    #[test]
+    fn short_run() {
+        check_test(&mut IncorrectDelimiterChecker::default(), [("F=BAR", None)]);
     }
 }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -42,38 +42,22 @@ impl Check for KeyWithoutValueChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    #[test]
-    fn working_run_with_value() {
-        let mut checker = KeyWithoutValueChecker::default();
-        let line = line_entry(1, 1, "FOO=BAR");
-        assert_eq!(None, checker.run(&line));
+    check_tester!{
+        KeyWithoutValueChecker;
+        working_run_with_value => {
+            "FOO=BAR" => None,
+        },
+        working_run_with_blank_line => {
+            "" => None,
+        },
+        working_run_without_value => {
+            "FOO=" => None,
+        },
+        failing_run => {
+            "FOO" => Some("The FOO key should be with a value or have an equal sign"),
+        }
     }
 
-    #[test]
-    fn working_run_with_blank_line() {
-        let mut checker = KeyWithoutValueChecker::default();
-        let line = line_entry(1, 1, "");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_run_without_value() {
-        let mut checker = KeyWithoutValueChecker::default();
-        let line = line_entry(1, 1, "FOO=");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_run() {
-        let mut checker = KeyWithoutValueChecker::default();
-        let line = line_entry(1, 1, "FOO");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "KeyWithoutValue",
-            "The FOO key should be with a value or have an equal sign",
-        ));
-        assert_eq!(expected, checker.run(&line));
-    }
 }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-    check_tester!{
+    check_tester! {
         KeyWithoutValueChecker;
         working_run_with_value => {
             "FOO=BAR" => None,
@@ -59,5 +59,4 @@ mod tests {
             "FOO" => Some("The FOO key should be with a value or have an equal sign"),
         }
     }
-
 }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -42,21 +42,31 @@ impl Check for KeyWithoutValueChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        KeyWithoutValueChecker;
-        working_run_with_value => {
-            "FOO=BAR" => None,
-        },
-        working_run_with_blank_line => {
-            "" => None,
-        },
-        working_run_without_value => {
-            "FOO=" => None,
-        },
-        failing_run => {
-            "FOO" => Some("The FOO key should be with a value or have an equal sign"),
-        }
+    #[test]
+    fn working_run_with_value() {
+        check_test(&mut KeyWithoutValueChecker::default(), [("FOO=BAR", None)]);
+    }
+
+    #[test]
+    fn working_run_with_blank_line() {
+        check_test(&mut KeyWithoutValueChecker::default(), [("", None)]);
+    }
+
+    #[test]
+    fn working_run_without_value() {
+        check_test(&mut KeyWithoutValueChecker::default(), [("FOO=", None)]);
+    }
+
+    #[test]
+    fn failing_run() {
+        check_test(
+            &mut KeyWithoutValueChecker::default(),
+            [(
+                "FOO",
+                Some("The FOO key should be with a value or have an equal sign"),
+            )],
+        );
     }
 }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -46,7 +46,7 @@ mod tests {
 
     const MESSAGE: &str = "Invalid leading character detected";
 
-    check_tester!{
+    check_tester! {
         LeadingCharacterChecker;
         no_leading_chars_test => {
             "FOO=BAR" => None,

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -42,38 +42,73 @@ impl Check for LeadingCharacterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
     const MESSAGE: &str = "Invalid leading character detected";
 
-    check_tester! {
-        LeadingCharacterChecker;
-        no_leading_chars_test => {
-            "FOO=BAR" => None,
-        },
-        blank_line => {
-            "" => None,
-        },
-        leading_underscore => {
-            "_FOO=BAR" => None,
-        },
-        leading_dot => {
-            ".FOO=BAR" => Some(MESSAGE),
-        },
-        leading_asterisk => {
-            "*FOO=BAR" => Some(MESSAGE),
-        },
-        leading_number => {
-            "1FOO=BAR" => Some(MESSAGE),
-        },
-        leading_space => {
-            " FOO=BAR" => Some(MESSAGE),
-        },
-        two_leading_spaces => {
-            "  FOO=BAR" => Some(MESSAGE),
-        },
-        leading_tab => {
-            "\tFOO=BAR" => Some(MESSAGE),
-        }
+    #[test]
+    fn no_leading_chars_test() {
+        check_test(&mut LeadingCharacterChecker::default(), [("FOO=BAR", None)]);
+    }
+
+    #[test]
+    fn blank_line() {
+        check_test(&mut LeadingCharacterChecker::default(), [("", None)]);
+    }
+
+    #[test]
+    fn leading_underscore() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [("_FOO=BAR", None)],
+        );
+    }
+
+    #[test]
+    fn leading_dot() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [(".FOO=BAR", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn leading_asterisk() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [("*FOO=BAR", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn leading_number() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [("1FOO=BAR", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn leading_space() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [(" FOO=BAR", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn two_leading_spaces() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [("  FOO=BAR", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn leading_tab() {
+        check_test(
+            &mut LeadingCharacterChecker::default(),
+            [("\tFOO=BAR", Some(MESSAGE))],
+        );
     }
 }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -42,82 +42,38 @@ impl Check for LeadingCharacterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
     const MESSAGE: &str = "Invalid leading character detected";
 
-    #[test]
-    fn no_leading_chars_test() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "FOO=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn blank_line() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn leading_underscore() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "_FOO=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn leading_dot() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, ".FOO=BAR");
-        assert_eq!(
-            Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE)),
-            checker.run(&line)
-        );
-    }
-
-    #[test]
-    fn leading_asterisk() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "*FOO=BAR");
-        assert_eq!(
-            Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE)),
-            checker.run(&line)
-        );
-    }
-
-    #[test]
-    fn leading_number() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "1FOO=BAR");
-        assert_eq!(
-            Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE)),
-            checker.run(&line)
-        );
-    }
-
-    #[test]
-    fn leading_space() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, " FOO=BAR");
-        let expected = Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn two_leading_spaces() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "  FOO=BAR");
-        let expected = Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn leading_tab() {
-        let mut checker = LeadingCharacterChecker::default();
-        let line = line_entry(1, 1, "\tFOO=BAR");
-        let expected = Some(Warning::new(line.clone(), "LeadingCharacter", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
+    check_tester!{
+        LeadingCharacterChecker;
+        no_leading_chars_test => {
+            "FOO=BAR" => None,
+        },
+        blank_line => {
+            "" => None,
+        },
+        leading_underscore => {
+            "_FOO=BAR" => None,
+        },
+        leading_dot => {
+            ".FOO=BAR" => Some(MESSAGE),
+        },
+        leading_asterisk => {
+            "*FOO=BAR" => Some(MESSAGE),
+        },
+        leading_number => {
+            "1FOO=BAR" => Some(MESSAGE),
+        },
+        leading_space => {
+            " FOO=BAR" => Some(MESSAGE),
+        },
+        two_leading_spaces => {
+            "  FOO=BAR" => Some(MESSAGE),
+        },
+        leading_tab => {
+            "\tFOO=BAR" => Some(MESSAGE),
+        }
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -39,21 +39,40 @@ impl LowercaseKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        LowercaseKeyChecker;
-        working_run => {
-            "FOO=BAR" => None,
-        },
-        working_with_export_run => {
-            "export FOO=BAR" => None,
-        },
-        failing_run_with_lowercase_key => {
-            "foo_bar=FOOBAR" => Some("The foo_bar key should be in uppercase"),
-        },
-        failing_run_with_lowercase_letter => {
-            "FOo_BAR=FOOBAR" => Some("The FOo_BAR key should be in uppercase"),
-        }
+    #[test]
+    fn working_run() {
+        check_test(&mut LowercaseKeyChecker::default(), [("FOO=BAR", None)]);
+    }
+
+    #[test]
+    fn working_with_export_run() {
+        check_test(
+            &mut LowercaseKeyChecker::default(),
+            [("export FOO=BAR", None)],
+        );
+    }
+
+    #[test]
+    fn failing_run_with_lowercase_key() {
+        check_test(
+            &mut LowercaseKeyChecker::default(),
+            [(
+                "foo_bar=FOOBAR",
+                Some("The foo_bar key should be in uppercase"),
+            )],
+        );
+    }
+
+    #[test]
+    fn failing_run_with_lowercase_letter() {
+        check_test(
+            &mut LowercaseKeyChecker::default(),
+            [(
+                "FOo_BAR=FOOBAR",
+                Some("The FOo_BAR key should be in uppercase"),
+            )],
+        );
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -39,43 +39,21 @@ impl LowercaseKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    #[test]
-    fn working_run() {
-        let mut checker = LowercaseKeyChecker::default();
-        let line = line_entry(1, 1, "FOO=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_with_export_run() {
-        let mut checker = LowercaseKeyChecker::default();
-        let line = line_entry(1, 1, "export FOO=BAR");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_run_with_lowercase_key() {
-        let mut checker = LowercaseKeyChecker::default();
-        let line = line_entry(1, 1, "foo_bar=FOOBAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "LowercaseKey",
-            "The foo_bar key should be in uppercase",
-        ));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_run_with_lowercase_letter() {
-        let mut checker = LowercaseKeyChecker::default();
-        let line = line_entry(1, 1, "FOo_BAR=FOOBAR");
-        let expected = Some(Warning::new(
-            line.clone(),
-            "LowercaseKey",
-            "The FOo_BAR key should be in uppercase",
-        ));
-        assert_eq!(expected, checker.run(&line));
+    check_tester!{
+        LowercaseKeyChecker;
+        working_run => {
+            "FOO=BAR" => None,
+        },
+        working_with_export_run => {
+            "export FOO=BAR" => None,
+        },
+        failing_run_with_lowercase_key => {
+            "foo_bar=FOOBAR" => Some("The foo_bar key should be in uppercase"),
+        },
+        failing_run_with_lowercase_letter => {
+            "FOo_BAR=FOOBAR" => Some("The FOo_BAR key should be in uppercase"),
+        }
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -41,7 +41,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-    check_tester!{
+    check_tester! {
         LowercaseKeyChecker;
         working_run => {
             "FOO=BAR" => None,

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -43,29 +43,45 @@ impl Check for QuoteCharacterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
     const WARNING: &str = "The value has quote characters (\', \")";
 
-    check_tester! {
-        QuoteCharacterChecker;
-        with_single_quote_test => {
-            "FOO=BAR" => None,
-            "FOO='BAR'" => Some(WARNING),
-            "FOO='B\"AR'" => Some(WARNING),
-            "FOO=\'BAR BAR\'" => None,
-        },
-        with_double_quote_test => {
-            "FOO=BAR" => None,
-            "FOO=\"BAR\"" => Some(WARNING),
-            "FOO=\"BAR BAR\"" => None,
-        },
-        with_substitution_keys_test => {
-            "BAR=\"$ABC\"" => None,
-            "FOO='${BAR}BAR'" => None,
-        },
-        with_no_quotes_test => {
-            "FOO=BAR" => None,
-        }
+    #[test]
+    fn with_single_quote_test() {
+        check_test(
+            &mut QuoteCharacterChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("FOO='BAR'", Some(WARNING)),
+                ("FOO='B\"AR'", Some(WARNING)),
+                ("FOO=\'BAR BAR\'", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn with_double_quote_test() {
+        check_test(
+            &mut QuoteCharacterChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("FOO=\"Bar\"", Some(WARNING)),
+                ("FOO=\"BAR BAR\"", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn with_substitution_keys_test() {
+        check_test(
+            &mut QuoteCharacterChecker::default(),
+            [("BAR=\"$ABC\"", None), ("FOO='${BAR}BAR'", None)],
+        );
+    }
+
+    #[test]
+    fn with_no_quotes_test() {
+        check_test(&mut QuoteCharacterChecker::default(), [("FOO=BAR", None)]);
     }
 }

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -47,7 +47,7 @@ mod tests {
 
     const WARNING: &str = "The value has quote characters (\', \")";
 
-    check_tester!{
+    check_tester! {
         QuoteCharacterChecker;
         with_single_quote_test => {
             "FOO=BAR" => None,

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -43,75 +43,29 @@ impl Check for QuoteCharacterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    fn run_quote_char_tests(asserts: Vec<(LineEntry, Option<Warning>)>) {
-        let mut checker = QuoteCharacterChecker::default();
+    const WARNING: &str = "The value has quote characters (\', \")";
 
-        for assert in asserts {
-            let (input, output) = assert;
-            assert_eq!(checker.run(&input), output);
+    check_tester!{
+        QuoteCharacterChecker;
+        with_single_quote_test => {
+            "FOO=BAR" => None,
+            "FOO='BAR'" => Some(WARNING),
+            "FOO='B\"AR'" => Some(WARNING),
+            "FOO=\'BAR BAR\'" => None,
+        },
+        with_double_quote_test => {
+            "FOO=BAR" => None,
+            "FOO=\"BAR\"" => Some(WARNING),
+            "FOO=\"BAR BAR\"" => None,
+        },
+        with_substitution_keys_test => {
+            "BAR=\"$ABC\"" => None,
+            "FOO='${BAR}BAR'" => None,
+        },
+        with_no_quotes_test => {
+            "FOO=BAR" => None,
         }
-    }
-
-    #[test]
-    fn with_single_quote_test() {
-        let asserts = vec![
-            (line_entry(1, 4, "FOO=BAR"), None),
-            (
-                line_entry(2, 4, "FOO='BAR'"),
-                Some(Warning::new(
-                    line_entry(2, 4, "FOO='BAR'"),
-                    "QuoteCharacter",
-                    "The value has quote characters (\', \")",
-                )),
-            ),
-            (
-                line_entry(3, 4, "FOO='B\"AR'"),
-                Some(Warning::new(
-                    line_entry(3, 4, "FOO='B\"AR'"),
-                    "QuoteCharacter",
-                    "The value has quote characters (\', \")",
-                )),
-            ),
-            (line_entry(4, 4, "FOO=\'BAR BAR\'"), None),
-        ];
-
-        run_quote_char_tests(asserts);
-    }
-
-    #[test]
-    fn with_double_quote_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "FOO=BAR"), None),
-            (
-                line_entry(2, 3, "FOO=\"BAR\""),
-                Some(Warning::new(
-                    line_entry(2, 3, "FOO=\"BAR\""),
-                    "QuoteCharacter",
-                    "The value has quote characters (\', \")",
-                )),
-            ),
-            (line_entry(3, 3, "FOO=\"BAR BAR\""), None),
-        ];
-
-        run_quote_char_tests(asserts);
-    }
-
-    #[test]
-    fn with_substitution_keys_test() {
-        let asserts = vec![
-            (line_entry(1, 2, "BAR=\"$ABC\""), None),
-            (line_entry(2, 2, "FOO='${BAR}BAR'"), None),
-        ];
-
-        run_quote_char_tests(asserts);
-    }
-
-    #[test]
-    fn with_no_quotes_test() {
-        let asserts = vec![(line_entry(1, 1, "FOO=BAR"), None)];
-
-        run_quote_char_tests(asserts);
     }
 }

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -46,7 +46,7 @@ mod tests {
 
     const MESSAGE: &str = "The line has spaces around equal sign";
 
-    check_tester!{
+    check_tester! {
         SpaceCharacterChecker;
         working_run => {
             "DEBUG_HTTP=true" => None,

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -42,66 +42,35 @@ impl Check for SpaceCharacterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
     const MESSAGE: &str = "The line has spaces around equal sign";
 
-    #[test]
-    fn working_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "DEBUG_HTTP=true");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_leading_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, " DEBUG_HTTP=true");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_trailing_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "DEBUG_HTTP=true ");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_empty_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn working_no_equal_sign_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "DEBUG_HTTP true");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "DEBUG-HTTP = true");
-        let expected = Some(Warning::new(line.clone(), "SpaceCharacter", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_when_whitespace_before_equal_sign_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "DEBUG-HTTP =true");
-        let expected = Some(Warning::new(line.clone(), "SpaceCharacter", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_when_whitespace_after_equal_sign_run() {
-        let mut checker = SpaceCharacterChecker::default();
-        let line = line_entry(1, 1, "DEBUG-HTTP= true");
-        let expected = Some(Warning::new(line.clone(), "SpaceCharacter", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
+    check_tester!{
+        SpaceCharacterChecker;
+        working_run => {
+            "DEBUG_HTTP=true" => None,
+        },
+        working_leading_run => {
+            " DEBUG_HTTP=true" => None,
+        },
+        working_trailing_run => {
+            "DEBUG_HTTP=true " => None,
+        },
+        working_empty_run => {
+            "" => None,
+        },
+        working_no_equal_sign_run => {
+            "DEBUG_HTTP true" => None,
+        },
+        failing_run => {
+            "DEBUG-HTTP = true" => Some(MESSAGE),
+        },
+        failing_when_whitespace_before_equal_sign_run => {
+            "DEBUG-HTTP =true" => Some(MESSAGE),
+        },
+        failing_when_whitespace_after_equal_sign_run => {
+            "DEBUG-HTTP= true" => Some(MESSAGE),
+        }
     }
 }

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -42,35 +42,68 @@ impl Check for SpaceCharacterChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
     const MESSAGE: &str = "The line has spaces around equal sign";
 
-    check_tester! {
-        SpaceCharacterChecker;
-        working_run => {
-            "DEBUG_HTTP=true" => None,
-        },
-        working_leading_run => {
-            " DEBUG_HTTP=true" => None,
-        },
-        working_trailing_run => {
-            "DEBUG_HTTP=true " => None,
-        },
-        working_empty_run => {
-            "" => None,
-        },
-        working_no_equal_sign_run => {
-            "DEBUG_HTTP true" => None,
-        },
-        failing_run => {
-            "DEBUG-HTTP = true" => Some(MESSAGE),
-        },
-        failing_when_whitespace_before_equal_sign_run => {
-            "DEBUG-HTTP =true" => Some(MESSAGE),
-        },
-        failing_when_whitespace_after_equal_sign_run => {
-            "DEBUG-HTTP= true" => Some(MESSAGE),
-        }
+    #[test]
+    fn working_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [("DEBUG_HTTP=true", None)],
+        );
+    }
+
+    #[test]
+    fn working_leading_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [(" DEBUG_HTTP=true", None)],
+        );
+    }
+
+    #[test]
+    fn working_trailing_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [("DEBUG_HTTP=true ", None)],
+        );
+    }
+
+    #[test]
+    fn working_empty_run() {
+        check_test(&mut SpaceCharacterChecker::default(), [("", None)]);
+    }
+
+    #[test]
+    fn working_no_equal_sign_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [("DEBUG_HTTP true", None)],
+        );
+    }
+
+    #[test]
+    fn failing_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [("DEBUG_HTTP = true", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn failing_when_whitespace_before_equal_sign_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [("DEBUG_HTTP =true", Some(MESSAGE))],
+        );
+    }
+
+    #[test]
+    fn failing_when_whitespace_after_equal_sign_run() {
+        check_test(
+            &mut SpaceCharacterChecker::default(),
+            [("DEBUG_HTTP= true", Some(MESSAGE))],
+        );
     }
 }

--- a/src/checks/substitution_key.rs
+++ b/src/checks/substitution_key.rs
@@ -72,35 +72,75 @@ impl SubstitutionKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        SubstitutionKeyChecker;
-        correct_substitution_key_test => {
-            "ABC=$BAR" => None,
-            "FOO=${BAR}" => None,
-            "FOO=\"$BAR\"" => None,
-        },
-        incorrect_substitution_key_test => {
-            "ABC=${BAR" => Some("The ABC key is not assigned properly"),
-            "FOO=${BAR!}" => Some("The FOO key is not assigned properly"),
-            "XYZ=$BAR}" => Some("The XYZ key is not assigned properly"),
-        },
-        multiple_substitution_key_test => {
-            "ABC=${BAR}$XYZ" => None,
-            "FOO=$ABC{${BAR}" => None,
-            "BIZ=$FOO-$ABC" => None,
-        },
-        incorrect_multiple_substitution_key_test => {
-            "ABC=${BAR$XYZ}" => Some("The ABC key is not assigned properly"),
-            "FOO=${ABC-$BAR}" => Some("The FOO key is not assigned properly"),
-            "XYZ=${FOO${BAR}" => Some("The XYZ key is not assigned properly"),
-        },
-        escaped_incorrect_substitution_key_test => {
-            "ABC=\\${BAR" => None,
-            "FOO=\\$BAR}" => None,
-            "FOO=\"\\${BAR\"" => None,
-            "FOO=\"\\$BAR}" => None,
-        }
+    #[test]
+    fn correct_substitution_key_test() {
+        check_test(
+            &mut SubstitutionKeyChecker::default(),
+            [
+                ("ABC=$BAR", None),
+                ("FOO=${BAR}", None),
+                ("FOO=\"$BAR\"", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn incorrect_substitution_key_test() {
+        check_test(
+            &mut SubstitutionKeyChecker::default(),
+            [
+                ("ABC=${BAR", Some("The ABC key is not assigned properly")),
+                ("FOO=${BAR!}", Some("The FOO key is not assigned properly")),
+                ("XYZ=$BAR}", Some("The XYZ key is not assigned properly")),
+            ],
+        );
+    }
+
+    #[test]
+    fn multiple_substitution_key_test() {
+        check_test(
+            &mut SubstitutionKeyChecker::default(),
+            [
+                ("ABC=${BAR}$XYZ", None),
+                ("FOO=$ABC{${BAR}", None),
+                ("BIZ=$FOO-$ABC", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn incorrect_multiple_substitution_key_test() {
+        check_test(
+            &mut SubstitutionKeyChecker::default(),
+            [
+                (
+                    "ABC=${BAR$XYZ}",
+                    Some("The ABC key is not assigned properly"),
+                ),
+                (
+                    "FOO=${ABC-$BAR}",
+                    Some("The FOO key is not assigned properly"),
+                ),
+                (
+                    "XYZ=${FOO${BAR}",
+                    Some("The XYZ key is not assigned properly"),
+                ),
+            ],
+        );
+    }
+
+    #[test]
+    fn escaped_incorrect_substitution_key_test() {
+        check_test(
+            &mut SubstitutionKeyChecker::default(),
+            [
+                ("ABC=\\${BAR", None),
+                ("FOO=\\$BAR}", None),
+                ("FOO=\"\\${BAR\"", None),
+                ("FOO=\"\\$BAR}", None),
+            ],
+        );
     }
 }

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -40,17 +40,23 @@ impl Check for TrailingWhitespaceChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
     const MESSAGE: &str = "Trailing whitespace detected";
 
-    check_tester! {
-        TrailingWhitespaceChecker;
-        working_run => {
-            "DEBUG_HTTP=true" => None,
-        },
-        failing_trailing_run => {
-            "DEBUG_HTTP=true  " => Some(MESSAGE),
-        }
+    #[test]
+    fn working_run() {
+        check_test(
+            &mut TrailingWhitespaceChecker::default(),
+            [("DEBUG_HTTP=true", None)],
+        );
+    }
+
+    #[test]
+    fn failing_trailing_run() {
+        check_test(
+            &mut TrailingWhitespaceChecker::default(),
+            [("DEBUG_HTTP=true  ", Some(MESSAGE))],
+        );
     }
 }

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -40,22 +40,17 @@ impl Check for TrailingWhitespaceChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
     const MESSAGE: &str = "Trailing whitespace detected";
 
-    #[test]
-    fn working_run() {
-        let mut checker = TrailingWhitespaceChecker::default();
-        let line = line_entry(1, 1, "DEBUG_HTTP=true");
-        assert_eq!(None, checker.run(&line));
-    }
-
-    #[test]
-    fn failing_trailing_run() {
-        let mut checker = TrailingWhitespaceChecker::default();
-        let line = line_entry(1, 1, "DEBUG_HTTP=true  ");
-        let expected = Some(Warning::new(line.clone(), "TrailingWhitespace", MESSAGE));
-        assert_eq!(expected, checker.run(&line));
+    check_tester!{
+        TrailingWhitespaceChecker;
+        working_run => {
+            "DEBUG_HTTP=true" => None,
+        },
+        failing_trailing_run => {
+            "DEBUG_HTTP=true  " => Some(MESSAGE),
+        }
     }
 }

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -44,7 +44,7 @@ mod tests {
 
     const MESSAGE: &str = "Trailing whitespace detected";
 
-    check_tester!{
+    check_tester! {
         TrailingWhitespaceChecker;
         working_run => {
             "DEBUG_HTTP=true" => None,

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -69,78 +69,139 @@ impl Check for UnorderedKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{check_tester, common::tests::*};
+    use crate::common::tests::*;
 
-    check_tester! {
-        UnorderedKeyChecker;
-        one_key_test => {
-            "" => None,
-        },
-        two_ordered_keys_test => {
-            "" => None,
-            "" => None,
-        },
-        one_unordered_key_test => {
-            "FOO=BAR" => None,
-            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
-        },
-        two_unordered_keys_before_test => {
-            "FOO=BAR" => None,
-            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
-            "ABC=BAR" => Some("The ABC key should go before the BAR key"),
-        },
-        two_unordered_keys_before_and_after_test => {
-            "FOO=BAR" => None,
-            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
-            "DDD=BAR" => Some("The DDD key should go before the FOO key"),
-        },
-        two_ordered_and_two_unordered_keys_test => {
-            "FOO=BAR" => None,
-            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
-            "DDD=BAR" => Some("The DDD key should go before the FOO key"),
-            "ZOO=BAR" => None,
-        },
-        one_unordered_key_with_blank_line_test => {
-            "FOO=BAR" => None,
-            "" => None,
-            "BAR=FOO" => None,
-        },
-        one_unordered_key_with_control_comment_test => {
-            "FOO=BAR" => None,
-            "# dotenv-linter:off LowercaseKey" => None,
-            "Bar=FOO" => None,
-        },
-        two_ordered_groups_with_two_substitution_keys_test => {
-            "ABC=XYZ" => None,
-            "KEY=VALUE" => None,
-            "FOO=$KEY # Unordered, FOO uses KEY" => None,
-            "BAR=FOO" => None,
-            "BOO=$FOO" => None,
-            "XYZ=ABC" => None,
-        },
-        three_ordered_groups_with_two_unordered_substitution_keys_that_have_multiple_values_test => {
-            "BBB=XYZ" => None,
-            "HHH=VAL" => None,
-            "ZZZ=VALUE" => None,
-            "CCC=$NNN$HHH # Unordered, CCC uses HHH" => None,
-            "BAR=FOOD" => None,
-            "BIG=FOOT" => None,
-            "WWW=$XYZ$TTT" => None,
-            "YYY=FOO" => None,
-            "BOO=$BAR$BBB$ZZZ # Unordered, BOO uses BAR" => None,
-            "TTT=BIG" => None,
-            "XYZ=G" => None,
-        },
-        two_unordered_groups_before_and_after_unordered_substitution_keys_test => {
-            "HHH=VAL" => None,
-            "ZZZ=VALUE" => None,
-            "BBB=$XYZ" => Some("The BBB key should go before the HHH key"),
-            "CCC=$HHH # Unordered, CCC uses HHH" => None,
-            "TTT=BIG" => None,
-            "XYZ=G" => None,
-            "GGG=JJJ" => Some("The GGG key should go before the TTT key"),
-            "AAA=$ZZZ" => Some("The AAA key should go before the GGG key"),
-            "MMM=$GGG$ZZZ # Unordered, MMM uses GGG" => None,
-        }
+    #[test]
+    fn one_key_test() {
+        check_test(&mut UnorderedKeyChecker::default(), [("", None)]);
+    }
+
+    #[test]
+    fn two_ordered_key_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [("", None), ("", None)],
+        );
+    }
+
+    #[test]
+    fn one_unordered_key_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("BAR=FOO", Some("The BAR key should go before the FOO key")),
+            ],
+        );
+    }
+
+    #[test]
+    fn two_unordered_keys_before_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("BAR=FOO", Some("The BAR key should go before the FOO key")),
+                ("ABC=BAR", Some("The ABC key should go before the BAR key")),
+            ],
+        );
+    }
+
+    #[test]
+    fn two_unordered_keys_before_and_after_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("BAR=FOO", Some("The BAR key should go before the FOO key")),
+                ("DDD=BAR", Some("The DDD key should go before the FOO key")),
+            ],
+        );
+    }
+
+    #[test]
+    fn two_ordered_and_two_unordered_keys_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("BAR=FOO", Some("The BAR key should go before the FOO key")),
+                ("DDD=BAR", Some("The DDD key should go before the FOO key")),
+                ("ZOO=BAR", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn one_unordered_key_with_blank_line_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [("FOO=BAR", None), ("", None), ("BAR=FOO", None)],
+        );
+    }
+
+    #[test]
+    fn one_unordered_key_with_control_comment_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("# dotenv-linter:off LowercaseKey", None),
+                ("Bar=FOO", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn two_ordered_groups_with_two_substitution_keys_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("ABC=XYZ", None),
+                ("KEY=VALUE", None),
+                ("FOO=$KEY # Unordered, FOO uses KEY", None),
+                ("BAR=FOO", None),
+                ("BOO=$FOO", None),
+                ("XYZ=ABC", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn three_ordered_groups_with_two_unordered_substitution_keys_that_have_multiple_values_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("BBB=XYZ", None),
+                ("HHH=VAL", None),
+                ("ZZZ=VALUE", None),
+                ("CCC=$NNN$HHH # Unordered, CCC uses HHH", None),
+                ("BAR=FOOD", None),
+                ("BIG=FOOT", None),
+                ("WWW=$XYZ$TTT", None),
+                ("YYY=FOO", None),
+                ("BOO=$BAR$BBB$ZZZ # Unordered, BOO uses BAR", None),
+                ("TTT=BIG", None),
+                ("XYZ=G", None),
+            ],
+        );
+    }
+
+    #[test]
+    fn two_unordered_groups_before_and_after_unordered_substitution_keys_test() {
+        check_test(
+            &mut UnorderedKeyChecker::default(),
+            [
+                ("HHH=VAL", None),
+                ("ZZZ=VALUE", None),
+                ("BBB=$XYZ", Some("The BBB key should go before the HHH key")),
+                ("CCC=$HHH # Unordered, CCC uses HHH", None),
+                ("TTT=BIG", None),
+                ("XYZ=G", None),
+                ("GGG=JJJ", Some("The GGG key should go before the TTT key")),
+                ("AAA=$ZZZ", Some("The AAA key should go before the GGG key")),
+                ("MMM=$GGG$ZZZ # Unordered, MMM uses GGG", None),
+            ],
+        );
     }
 }

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -71,8 +71,7 @@ mod tests {
     use super::*;
     use crate::{check_tester, common::tests::*};
 
-
-    check_tester!{
+    check_tester! {
         UnorderedKeyChecker;
         one_key_test => {
             "" => None,
@@ -130,7 +129,7 @@ mod tests {
             "YYY=FOO" => None,
             "BOO=$BAR$BBB$ZZZ # Unordered, BOO uses BAR" => None,
             "TTT=BIG" => None,
-            "XYZ=G" => None, 
+            "XYZ=G" => None,
         },
         two_unordered_groups_before_and_after_unordered_substitution_keys_test => {
             "HHH=VAL" => None,

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -69,223 +69,79 @@ impl Check for UnorderedKeyChecker<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::tests::*;
+    use crate::{check_tester, common::tests::*};
 
-    fn run_unordered_tests(asserts: Vec<(LineEntry, Option<Warning>)>) {
-        let mut checker = UnorderedKeyChecker::default();
 
-        for assert in asserts {
-            let (input, output) = assert;
-            assert_eq!(checker.run(&input), output);
+    check_tester!{
+        UnorderedKeyChecker;
+        one_key_test => {
+            "" => None,
+        },
+        two_ordered_keys_test => {
+            "" => None,
+            "" => None,
+        },
+        one_unordered_key_test => {
+            "FOO=BAR" => None,
+            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
+        },
+        two_unordered_keys_before_test => {
+            "FOO=BAR" => None,
+            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
+            "ABC=BAR" => Some("The ABC key should go before the BAR key"),
+        },
+        two_unordered_keys_before_and_after_test => {
+            "FOO=BAR" => None,
+            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
+            "DDD=BAR" => Some("The DDD key should go before the FOO key"),
+        },
+        two_ordered_and_two_unordered_keys_test => {
+            "FOO=BAR" => None,
+            "BAR=FOO" => Some("The BAR key should go before the FOO key"),
+            "DDD=BAR" => Some("The DDD key should go before the FOO key"),
+            "ZOO=BAR" => None,
+        },
+        one_unordered_key_with_blank_line_test => {
+            "FOO=BAR" => None,
+            "" => None,
+            "BAR=FOO" => None,
+        },
+        one_unordered_key_with_control_comment_test => {
+            "FOO=BAR" => None,
+            "# dotenv-linter:off LowercaseKey" => None,
+            "Bar=FOO" => None,
+        },
+        two_ordered_groups_with_two_substitution_keys_test => {
+            "ABC=XYZ" => None,
+            "KEY=VALUE" => None,
+            "FOO=$KEY # Unordered, FOO uses KEY" => None,
+            "BAR=FOO" => None,
+            "BOO=$FOO" => None,
+            "XYZ=ABC" => None,
+        },
+        three_ordered_groups_with_two_unordered_substitution_keys_that_have_multiple_values_test => {
+            "BBB=XYZ" => None,
+            "HHH=VAL" => None,
+            "ZZZ=VALUE" => None,
+            "CCC=$NNN$HHH # Unordered, CCC uses HHH" => None,
+            "BAR=FOOD" => None,
+            "BIG=FOOT" => None,
+            "WWW=$XYZ$TTT" => None,
+            "YYY=FOO" => None,
+            "BOO=$BAR$BBB$ZZZ # Unordered, BOO uses BAR" => None,
+            "TTT=BIG" => None,
+            "XYZ=G" => None, 
+        },
+        two_unordered_groups_before_and_after_unordered_substitution_keys_test => {
+            "HHH=VAL" => None,
+            "ZZZ=VALUE" => None,
+            "BBB=$XYZ" => Some("The BBB key should go before the HHH key"),
+            "CCC=$HHH # Unordered, CCC uses HHH" => None,
+            "TTT=BIG" => None,
+            "XYZ=G" => None,
+            "GGG=JJJ" => Some("The GGG key should go before the TTT key"),
+            "AAA=$ZZZ" => Some("The AAA key should go before the GGG key"),
+            "MMM=$GGG$ZZZ # Unordered, MMM uses GGG" => None,
         }
-    }
-
-    #[test]
-    fn one_key_test() {
-        let asserts = vec![(line_entry(1, 1, ""), None)];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn two_ordered_keys_test() {
-        let asserts = vec![(line_entry(1, 2, ""), None), (line_entry(2, 2, ""), None)];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn one_unordered_key_test() {
-        let asserts = vec![
-            (line_entry(1, 2, "FOO=BAR"), None),
-            (
-                line_entry(2, 2, "BAR=FOO"),
-                Some(Warning::new(
-                    line_entry(2, 2, "BAR=FOO"),
-                    "UnorderedKey",
-                    "The BAR key should go before the FOO key",
-                )),
-            ),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn two_unordered_keys_before_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "FOO=BAR"), None),
-            (
-                line_entry(2, 3, "BAR=FOO"),
-                Some(Warning::new(
-                    line_entry(2, 3, "BAR=FOO"),
-                    "UnorderedKey",
-                    "The BAR key should go before the FOO key",
-                )),
-            ),
-            (
-                line_entry(3, 3, "ABC=BAR"),
-                Some(Warning::new(
-                    line_entry(3, 3, "ABC=BAR"),
-                    "UnorderedKey",
-                    "The ABC key should go before the BAR key",
-                )),
-            ),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn two_unordered_keys_before_and_after_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "FOO=BAR"), None),
-            (
-                line_entry(2, 3, "BAR=FOO"),
-                Some(Warning::new(
-                    line_entry(2, 3, "BAR=FOO"),
-                    "UnorderedKey",
-                    "The BAR key should go before the FOO key",
-                )),
-            ),
-            (
-                line_entry(3, 3, "DDD=BAR"),
-                Some(Warning::new(
-                    line_entry(3, 3, "DDD=BAR"),
-                    "UnorderedKey",
-                    "The DDD key should go before the FOO key",
-                )),
-            ),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn two_ordered_and_two_unordered_keys_test() {
-        let asserts = vec![
-            (line_entry(1, 4, "FOO=BAR"), None),
-            (
-                line_entry(2, 4, "BAR=FOO"),
-                Some(Warning::new(
-                    line_entry(2, 4, "BAR=FOO"),
-                    "UnorderedKey",
-                    "The BAR key should go before the FOO key",
-                )),
-            ),
-            (
-                line_entry(3, 4, "DDD=BAR"),
-                Some(Warning::new(
-                    line_entry(3, 4, "DDD=BAR"),
-                    "UnorderedKey",
-                    "The DDD key should go before the FOO key",
-                )),
-            ),
-            (line_entry(4, 4, "ZOO=BAR"), None),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn one_unordered_key_with_blank_line_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "FOO=BAR"), None),
-            (line_entry(2, 3, ""), None),
-            (line_entry(3, 3, "BAR=FOO"), None),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn one_unordered_key_with_control_comment_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "FOO=BAR"), None),
-            (line_entry(2, 3, "# dotenv-linter:off LowercaseKey"), None),
-            (line_entry(3, 3, "Bar=FOO"), None),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn two_ordered_groups_with_two_substitution_keys_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "ABC=XYZ"), None),
-            (line_entry(2, 3, "KEY=VALUE"), None),
-            (line_entry(3, 3, "FOO=$KEY # Unordered, FOO uses KEY"), None),
-            (line_entry(4, 3, "BAR=FOO"), None),
-            (line_entry(5, 3, "BOO=$FOO"), None),
-            (line_entry(6, 3, "XYZ=ABC"), None),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn three_ordered_groups_with_two_unordered_substitution_keys_that_have_multiple_values_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "BBB=XYZ"), None),
-            (line_entry(2, 3, "HHH=VAL"), None),
-            (line_entry(3, 3, "ZZZ=VALUE"), None),
-            (
-                line_entry(4, 3, "CCC=$NNN$HHH # Unordered, CCC uses HHH"),
-                None,
-            ),
-            (line_entry(5, 3, "BAR=FOOD"), None),
-            (line_entry(6, 3, "BIG=FOOT"), None),
-            (line_entry(7, 3, "WWW=$XYZ$TTT"), None),
-            (line_entry(8, 3, "YYY=FOO"), None),
-            (
-                line_entry(9, 3, "BOO=$BAR$BBB$ZZZ # Unordered, BOO uses BAR"),
-                None,
-            ),
-            (line_entry(10, 3, "TTT=BIG"), None),
-            (line_entry(11, 3, "XYZ=G"), None),
-        ];
-
-        run_unordered_tests(asserts);
-    }
-
-    #[test]
-    fn two_unordered_groups_before_and_after_unordered_substitution_keys_test() {
-        let asserts = vec![
-            (line_entry(1, 3, "HHH=VAL"), None),
-            (line_entry(2, 3, "ZZZ=VALUE"), None),
-            (
-                line_entry(3, 3, "BBB=$XYZ"),
-                Some(Warning::new(
-                    line_entry(3, 3, "BBB=$XYZ"),
-                    "UnorderedKey",
-                    "The BBB key should go before the HHH key",
-                )),
-            ),
-            (line_entry(4, 3, "CCC=$HHH # Unordered, CCC uses HHH"), None),
-            (line_entry(5, 3, "TTT=BIG"), None),
-            (line_entry(6, 3, "XYZ=G"), None),
-            (
-                line_entry(7, 3, "GGG=JJJ"),
-                Some(Warning::new(
-                    line_entry(7, 3, "GGG=JJJ"),
-                    "UnorderedKey",
-                    "The GGG key should go before the TTT key",
-                )),
-            ),
-            (
-                line_entry(8, 3, "AAA=$ZZZ"),
-                Some(Warning::new(
-                    line_entry(8, 3, "AAA=$ZZZ"),
-                    "UnorderedKey",
-                    "The AAA key should go before the GGG key",
-                )),
-            ),
-            (
-                line_entry(9, 3, "MMM=$GGG$ZZZ # Unordered, MMM uses GGG"),
-                None,
-            ),
-        ];
-
-        run_unordered_tests(asserts);
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -29,10 +29,10 @@ pub(crate) mod tests {
     use std::rc::Rc;
 
     /**
-        Helper function for testing `Check` implementations. 
+        Helper function for testing `Check` implementations.
 
         A `Check` implementation can be used against a number of &str inputs
-        and optional `Warning` messages respectively. 
+        and optional `Warning` messages respectively.
 
         This function construct `LineEntry`s and optional `Warning`s,
         if required, in order to assert that the `Check` implementation is creating
@@ -55,7 +55,7 @@ pub(crate) mod tests {
         any warnings, hence the `None`.
 
         The second line however, should expect a `Warning` with a message of
-        "The FOO key is duplicated". 
+        "The FOO key is duplicated".
     */
     pub fn check_test<'test, T, U>(checker: &mut T, asserts: U)
     where

--- a/src/common.rs
+++ b/src/common.rs
@@ -26,6 +26,75 @@ pub(crate) mod tests {
     use std::path::PathBuf;
     use std::rc::Rc;
 
+    /**
+       Creates test cases for Check trait implementations.
+
+       check_tester takes the name of the Check implementation which is
+       followed by the test cases.
+
+       Each test case is the same as a test function so multiple inputs
+       will occur on the same instance of the Check implementation, allowing
+       the implementation to use internal state (if required).
+
+       # Examples
+
+       The following example shows a single test case for the
+       DuplicatedKeyChecker:
+
+       ```
+       check_tester!{
+           DuplicatedKeyChecker;
+           duplicated_key_test => {
+               // First time seeing key "FOO" so is None
+               "FOO=BAR" => None,
+               // Second time seeing key "FOO" so is duplicate.
+               "FOO=BAR" => Some("The FOO key is duplicated"),
+           }
+       }
+       ```
+
+       The above example could be expanded as such:
+       ```
+        #[test]
+        fn duplicated_key_test() {
+            let mut checker = DuplicatedKeyChecker::default();
+
+            assert_eq!(None, checker.run(&line_entry(1, 2, "FOO=BAR")));
+            assert_eq!(Some(
+                Warning::new(
+                    line_entry(2, 2, "FOO=BAR")),
+                    "DuplicatedKey",
+                    "The FOO key is duplicated"
+                ),
+                checker.run(&line_entry(2, 2, "FOO=BAR"))
+            );
+        }
+       ```
+       As shown in the expanded example this macro will create the correct
+       Line_Entry for the checker and will also create the expected Warning
+       using the input and expected warning message.
+
+       ## Constant Warning Message
+
+       Note that the expected warning message does not need to be a string
+       literal; in the case where the warning message is always the same
+       a constant &str can be used:
+
+       ```
+        const WARNING: &str = "Invalid leading character detected";
+
+        check_tester!{
+            LeadingCharacterChecker;
+            leading_dot_is_not_valid => {
+                ".FOO=BAR" => Some(WARNING),
+            },
+            leading_number_is_not_valid => {
+                "1FOO=BAR" => Some(WARNING),
+            }
+        }
+       ```
+    */
+    #[cfg(test)]
     #[macro_export]
     macro_rules! check_tester {
         (@token $t:tt $sub:expr) => {$sub};

--- a/src/common/warning.rs
+++ b/src/common/warning.rs
@@ -14,8 +14,8 @@ impl Warning {
         let check_name = check_name.into();
         let message = message.into();
         Self {
-            line,
             check_name,
+            line,
             message,
         }
     }


### PR DESCRIPTION
Refactors the unit tests for Check implementations as per #419. 

Unit tests have been replaced with a new check_tester macro which takes care of the boiler plate of writing multiple test cases. This would make the tests easier to change when an interface change is required, such as #410, as only the expanded code of the macro is changed to reflect the new API.  

This change would also effect #414 and once that PR is merged I'm happy to make the changes so that it is included in this refactoring :)

Closes #419

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);

