### PR TITLE
Fixer tests refactoring

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -110,6 +110,40 @@ pub(crate) mod tests {
         assert_eq!("FOO-BAR", remove_invalid_leading_chars(string));
     }
 
+    /**
+    The purpose of this macro is to avoid boilerplate code while defining
+    input for tests in `Fix` trait implementations.
+    Since fixers work on a sequence of input lines and a set of warnings,
+    these tests often have to prepare a `Vec<LineEntry>` and a `Vec<Warning>`
+    to pass it to `Fix` methods.
+
+    Using this macro, input lines and warnings can be encoded in a vector
+    format, where each entry is a pair of a line and an optional warning
+    content. The macro takes care of determining the line numbers, thus
+    avoiding hard-coded integers.
+
+    Macro expands to a block whose value is of type
+    `(Vec<LineEntry>, Vec<Warning>)`.
+
+    # Examples:
+    ```
+    // input with 3 lines, 1 warning
+    let (lines, warnings) = lines_and_warnings![
+        "foO=BAR" => Some(("LowercaseKey","The FOO key should be in uppercase")),
+        "Z=Y" => None,
+        "" => None,
+    ];
+    ```
+
+    ```
+    // input with 3 lines, 0 warning
+    let (lines, warnings) = lines_and_warnings![
+        "FOO=BAR" => None,
+        "Z=Y" => None,
+        "" => None,
+    ];
+    ```
+    */
     #[cfg(test)]
     #[macro_export]
     macro_rules! lines_and_warnings {

--- a/src/common.rs
+++ b/src/common.rs
@@ -109,4 +109,27 @@ pub(crate) mod tests {
         let string = "***FOO-BAR";
         assert_eq!("FOO-BAR", remove_invalid_leading_chars(string));
     }
+
+    #[cfg(test)]
+    #[macro_export]
+    macro_rules! lines_and_warnings {
+        (
+            $(
+                // each repeat must contain `expr => expr`
+                $line:expr => $opt_msg:expr
+            ),* $(,)*
+            // ...zero or more, separated by commas
+        ) => {
+            // replace with multi-line statment block
+            {
+                let lines = vec![ $( $line ),* ];
+                let warnings = vec![ $( $opt_msg ),* ];
+                let line_warnings: Vec<(usize, &str)> = warnings
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, opt_msg)| opt_msg.and_then(|msg| Some((i, msg)) )).collect();
+                (lines, line_warnings)
+            }
+        };
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -25,6 +25,7 @@ pub fn remove_invalid_leading_chars(string: &str) -> &str {
 pub(crate) mod tests {
     use super::*;
     use crate::checks::Check;
+    use crate::fixes::Fix;
     use std::path::PathBuf;
     use std::rc::Rc;
 
@@ -111,72 +112,146 @@ pub(crate) mod tests {
     }
 
     /**
-    The purpose of this macro is to avoid boilerplate code while defining
-    input for tests in `Fix` trait implementations.
-    Since fixers work on a sequence of input lines and a set of warnings,
-    these tests often have to prepare a `Vec<LineEntry>` and a `Vec<Warning>`
-    to pass it to `Fix` methods.
+    `TestLine` is a helper type to prepare a line input for `Fix`
+    implementation tests. Since fixers work on a sequence of input
+    lines and a set of warnings, these tests require preparing line
+    entries and warnings mapping to those entries. `TestLine` make it
+    easier to define a test line entry with zero or more warnings
+    corresponding to the entry, in a manner independent of `LineEntry`
+    and `Warning` definitions.
 
-    Using this macro, input lines and warnings can be encoded in a vector
-    format, where each entry is a pair of a line and an optional warning
-    content. The macro takes care of determining the line numbers, thus
-    avoiding hard-coded integers.
-
-    Macro expands to a block whose value is of type
-    `(Vec<LineEntry>, Vec<Warning>)`.
-
-    # Examples:
+    Example of usage:
     ```
-    // input with 3 lines, 1 warning
-    let (lines, warnings) = lines_and_warnings![
-        "foO=BAR" => Some(("LowercaseKey","The FOO key should be in uppercase")),
-        "Z=Y" => None,
-        "" => None,
-    ];
-    ```
+    let lines = vec![
+       // line with no warning
+       TestLine::new("A=Foo"),
 
-    ```
-    // input with 3 lines, 0 warning
-    let (lines, warnings) = lines_and_warnings![
-        "FOO=BAR" => None,
-        "Z=Y" => None,
-        "" => None,
+       // line with one warning
+       TestLine::new("a=Foo").warning("LowercaseKey", "The a key should be in uppercase"),
+
+       // line with two warnings
+       TestLine::new("a")
+            .warning("LowercaseKey", "The a key should be in uppercase")
+            .warning(
+                "KeyWithoutValue",
+                "The a key should be with a value or have an equal sign",
+            ),
     ];
     ```
     */
-    #[cfg(test)]
-    #[macro_export]
-    macro_rules! lines_and_warnings {
-        (
-            $(
-                // each repeat must contain `expr => expr`
-                $line:expr => $opt_warning:expr
-            ),* $(,)*
-            // ...zero or more, separated by commas
-        ) => {
-            // replace with multi-line statment block
-            {
-                let lines_input = vec![ $( $line ),* ];
-                let warnings_input = vec![ $( $opt_warning ),* ];
-                let total_lines = lines_input.len();
+    pub struct TestLine<'l, 'w> {
+        line: &'l str,
+        warnings: Vec<(&'w str, &'w str)>,
+    }
 
-                let line_entries: Vec<LineEntry> = lines_input
-                    .iter()
-                    .enumerate()
-                    .map(|(i, content)| line_entry(i + 1, total_lines, content))
-                    .collect();
-
-                let warnings: Vec<Warning> = warnings_input
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, opt_warn)| {
-                        opt_warn.and_then(|(kind, msg): (&str, &str)| {
-                            Some(Warning::new(line_entries[i].clone(), kind, msg))
-                        })
-                    })
-                    .collect();
-                (line_entries, warnings)
+    impl<'l, 'w> TestLine<'l, 'w> {
+        pub fn new(line: &'l str) -> Self {
+            TestLine {
+                line,
+                warnings: Vec::new(),
             }
-        };
+        }
+
+        pub fn warning(mut self, name: &'w str, msg: &'w str) -> Self {
+            self.warnings.push((name, msg));
+            self
+        }
+    }
+
+    // Helper type to define a sequence of TestLines. It provides a
+    // method to prepare `Vec<LineEntry>` and `Vec<Warning>` output out of
+    // test lines input.
+    pub struct TestLineEntries<'l, 'w> {
+        test_lines: Vec<TestLine<'l, 'w>>,
+    }
+
+    impl<'l, 'w> TestLineEntries<'l, 'w> {
+        pub fn new(test_lines: Vec<TestLine<'l, 'w>>) -> Self {
+            TestLineEntries { test_lines }
+        }
+
+        pub fn lines_and_warnings(&self) -> (Vec<LineEntry>, Vec<Warning>) {
+            let mut line_no = 1;
+            let total_lines = self.test_lines.len();
+
+            let mut lines: Vec<LineEntry> = Vec::new();
+            let mut warnings: Vec<Warning> = Vec::new();
+
+            for test_line in &self.test_lines {
+                let new_entry = line_entry(line_no, total_lines, test_line.line);
+                for (w_name, w_msg) in &test_line.warnings {
+                    warnings.push(Warning::new(new_entry.clone(), *w_name, *w_msg));
+                }
+                lines.push(new_entry);
+                line_no += 1;
+            }
+            (lines, warnings)
+        }
+    }
+
+    impl<'l, 'w> From<Vec<TestLine<'l, 'w>>> for TestLineEntries<'l, 'w> {
+        fn from(test_lines: Vec<TestLine<'l, 'w>>) -> Self {
+            TestLineEntries::new(test_lines)
+        }
+    }
+
+    pub fn run_fix_warnings<F: Fix>(
+        fixer: &mut F,
+        test_lines: TestLineEntries,
+    ) -> (Option<usize>, Vec<String>) {
+        let (mut lines, mut warnings) = test_lines.lines_and_warnings();
+
+        let warnings_mut = warnings.iter_mut().collect();
+        let fix_count = fixer.fix_warnings(warnings_mut, &mut lines);
+
+        // Remove lines marked as deleted
+        lines.retain(|l| !l.is_deleted);
+
+        let fixed_lines: Vec<String> = lines.iter().map(|le| le.raw_string.clone()).collect();
+        (fix_count, fixed_lines)
+    }
+
+    #[test]
+    fn test_line_without_warning() {
+        let test_line = TestLine::new("A=Foo");
+        assert_eq!("A=Foo", test_line.line);
+        assert_eq!(0, test_line.warnings.len());
+    }
+
+    #[test]
+    fn test_line_with_single_warning() {
+        let test_line =
+            TestLine::new("a=Foo").warning("LowercaseKey", "The a key should be in uppercase");
+
+        assert_eq!("a=Foo", test_line.line);
+        assert_eq!(1, test_line.warnings.len());
+        assert_eq!(
+            ("LowercaseKey", "The a key should be in uppercase"),
+            test_line.warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_line_with_multi_warnings() {
+        let test_line = TestLine::new("a")
+            .warning("LowercaseKey", "The a key should be in uppercase")
+            .warning(
+                "KeyWithoutValue",
+                "The a key should be with a value or have an equal sign",
+            );
+
+        assert_eq!("a", test_line.line);
+        assert_eq!(2, test_line.warnings.len());
+        assert_eq!(
+            ("LowercaseKey", "The a key should be in uppercase"),
+            test_line.warnings[0]
+        );
+        assert_eq!(
+            (
+                "KeyWithoutValue",
+                "The a key should be with a value or have an equal sign"
+            ),
+            test_line.warnings[1]
+        );
     }
 }

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -95,6 +95,36 @@ pub fn run(warnings: &mut [Warning], lines: &mut Vec<LineEntry>, skip_checks: &[
 }
 
 #[cfg(test)]
+fn run_fix_warnings<F: Fix>(
+    fixer: &mut F,
+    lines: &[&str],
+    line_warnings: &[(usize, &str)],
+) -> (Option<usize>, Vec<String>) {
+    use crate::common::tests::line_entry;
+
+    let total_lines = lines.len();
+    let mut line_entries: Vec<LineEntry> = lines
+        .iter()
+        .enumerate()
+        .map(|(i, line)| line_entry(i + 1, total_lines, line))
+        .collect();
+
+    let mut warnings: Vec<Warning> = line_warnings
+        .iter()
+        .map(|(lno, msg)| Warning::new(line_entries[*lno].clone(), fixer.name(), *msg))
+        .collect();
+    let warning_ref = warnings.iter_mut().collect();
+
+    let fix_count = fixer.fix_warnings(warning_ref, &mut line_entries);
+    let fixed_lines: Vec<String> = line_entries
+        .iter()
+        .map(|le| le.raw_string.clone())
+        .collect();
+
+    (fix_count, fixed_lines)
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::common::tests::*;

--- a/src/fixes/duplicated_key.rs
+++ b/src/fixes/duplicated_key.rs
@@ -64,20 +64,19 @@ impl Fix for DuplicatedKeyFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_warnings() {
-        let mut fixer = DuplicatedKeyFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "Z=Y" => None,
-            "FOO=BAZ" => Some(("Duplicatedkey", "The Foo key is duplicated")),
-            "Z=X" => Some(("Duplicatedkey", "The Z key is duplicated")),
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut DuplicatedKeyFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new("Z=Y"),
+                TestLine::new("FOO=BAZ").warning("Duplicatedkey", "The Foo key is duplicated"),
+                TestLine::new("Z=X").warning("Duplicatedkey", "The Z key is duplicated"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(2), fix_count);
         assert_eq!(vec!["FOO=BAR", "Z=Y", "# FOO=BAZ", "# Z=X"], fixed_lines);
@@ -85,15 +84,16 @@ mod tests {
 
     #[test]
     fn fix_lines_without_warnings() {
-        let mut fixer = DuplicatedKeyFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "FOO=BAZ" => None,
-            "Z=Y" => None,
-            "Z=X" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut DuplicatedKeyFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new("FOO=BAZ"),
+                TestLine::new("Z=Y"),
+                TestLine::new("Z=X"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(0), fix_count);
         assert_eq!(vec!["FOO=BAR", "# FOO=BAZ", "Z=Y", "# Z=X"], fixed_lines);
@@ -101,16 +101,17 @@ mod tests {
 
     #[test]
     fn control_comment_at_first_line() {
-        let mut fixer = DuplicatedKeyFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "# dotenv-linter:off DuplicatedKey" => None,
-            "FOO=BAR" => None,
-            "FOO=BAZ" => None,
-            "Z=Y" => None,
-            "Z=X" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut DuplicatedKeyFixer::default(),
+            vec![
+                TestLine::new("# dotenv-linter:off DuplicatedKey"),
+                TestLine::new("FOO=BAR"),
+                TestLine::new("FOO=BAZ"),
+                TestLine::new("Z=Y"),
+                TestLine::new("Z=X"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(0), fix_count);
         assert_eq!(
@@ -127,18 +128,18 @@ mod tests {
 
     #[test]
     fn control_comment_in_the_middle() {
-        let mut fixer = DuplicatedKeyFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "# dotenv-linter:off DuplicatedKey" => None,
-            "FOO=BAZ" => None,
-            "Z=Y" => None,
-            "# dotenv-linter:on DuplicatedKey" => None,
-            "Z=X" => None,
-        ];
-
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut DuplicatedKeyFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new("# dotenv-linter:off DuplicatedKey"),
+                TestLine::new("FOO=BAZ"),
+                TestLine::new("Z=Y"),
+                TestLine::new("# dotenv-linter:on DuplicatedKey"),
+                TestLine::new("Z=X"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(0), fix_count);
         assert_eq!(
@@ -156,16 +157,17 @@ mod tests {
 
     #[test]
     fn unrelated_control_comment() {
-        let mut fixer = DuplicatedKeyFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "# dotenv-linter:off LowercaseKey" => None,
-            "FOO=BAR" => None,
-            "FOO=BAZ" => None,
-            "Z=Y" => None,
-            "Z=X" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut DuplicatedKeyFixer::default(),
+            vec![
+                TestLine::new("# dotenv-linter:off LowercaseKey"),
+                TestLine::new("FOO=BAR"),
+                TestLine::new("FOO=BAZ"),
+                TestLine::new("Z=Y"),
+                TestLine::new("Z=X"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(0), fix_count);
         assert_eq!(

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -40,27 +40,34 @@ impl Fix for EndingBlankLineFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_warnings_test() {
         let mut fixer = EndingBlankLineFixer::default();
-        let mut lines = vec![line_entry(1, 2, "FOO=BAR"), line_entry(2, 2, "Z=Y")];
-        let mut warning = Warning::new(
-            lines[1].clone(),
-            "EndingBlankLine",
-            "No blank line at the end of the file",
-        );
 
-        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
-        assert_eq!("\n", lines[2].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=BAR" => None,
+            "Z=Y" => Some(("EndingBlankLine","No blank line at the end of the file")),
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(vec!["FOO=BAR", "Z=Y", "\n"], fixed_lines);
     }
 
     #[test]
     fn ending_blank_line_exist_test() {
         let mut fixer = EndingBlankLineFixer::default();
-        let mut lines = vec![line_entry(1, 2, "FOO=BAR"), line_entry(2, 2, LF)];
 
-        assert_eq!(Some(0), fixer.fix_warnings(vec![], &mut lines));
-        assert_eq!(lines.len(), 2);
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=BAR" => None,
+            "\n" => None,
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(0), fix_count);
+        assert_eq!(vec!["FOO=BAR", "\n"], fixed_lines);
     }
 }

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -40,18 +40,18 @@ impl Fix for EndingBlankLineFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = EndingBlankLineFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "Z=Y" => Some(("EndingBlankLine","No blank line at the end of the file")),
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut EndingBlankLineFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new("Z=Y")
+                    .warning("EndingBlankLine", "No blank line at the end of the file"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(vec!["FOO=BAR", "Z=Y", "\n"], fixed_lines);
@@ -59,13 +59,10 @@ mod tests {
 
     #[test]
     fn ending_blank_line_exist_test() {
-        let mut fixer = EndingBlankLineFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "\n" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut EndingBlankLineFixer::default(),
+            vec![TestLine::new("FOO=BAR"), TestLine::new("\n")].into(),
+        );
 
         assert_eq!(Some(0), fix_count);
         assert_eq!(vec!["FOO=BAR", "\n"], fixed_lines);

--- a/src/fixes/extra_blank_line.rs
+++ b/src/fixes/extra_blank_line.rs
@@ -28,20 +28,18 @@ impl Fix for ExtraBlankLineFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn no_blank_lines_test() {
-        let mut fixer = ExtraBlankLineFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "" => None,
-            "HOGE=HUGA" => None,
-        ];
-
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut ExtraBlankLineFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new(""),
+                TestLine::new("HOGE=HUGA"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(0), fix_count);
         assert_eq!(vec!["FOO=BAR", "", "HOGE=HUGA"], fixed_lines);
@@ -49,16 +47,16 @@ mod tests {
 
     #[test]
     fn fix_one_extra_blank_line_test() {
-        let mut fixer = ExtraBlankLineFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "" => None,
-            "" => Some(("ExtraBlankLine", "Extra blank line detected")),
-            "HOGE=HUGA" => None,
-        ];
-
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut ExtraBlankLineFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new(""),
+                TestLine::new("").warning("ExtraBlankLine", "Extra blank line detected"),
+                TestLine::new("HOGE=HUGA"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(vec!["FOO=BAR", "", "HOGE=HUGA"], fixed_lines);
@@ -66,17 +64,17 @@ mod tests {
 
     #[test]
     fn fix_multiple_blank_lines_test() {
-        let mut fixer = ExtraBlankLineFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR" => None,
-            "" => None,
-            "" => Some(("ExtraBlankLine", "Extra blank line detected")),
-            "" => Some(("ExtraBlankLine", "Extra blank line detected")),
-            "HOGE=HUGA" => None,
-        ];
-
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut ExtraBlankLineFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR"),
+                TestLine::new(""),
+                TestLine::new("").warning("ExtraBlankLine", "Extra blank line detected"),
+                TestLine::new("").warning("ExtraBlankLine", "Extra blank line detected"),
+                TestLine::new("HOGE=HUGA"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(2), fix_count);
         assert_eq!(vec!["FOO=BAR", "", "HOGE=HUGA"], fixed_lines);

--- a/src/fixes/extra_blank_line.rs
+++ b/src/fixes/extra_blank_line.rs
@@ -28,53 +28,57 @@ impl Fix for ExtraBlankLineFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn no_blank_lines_test() {
         let mut fixer = ExtraBlankLineFixer::default();
 
-        let warnings = vec![];
-        let lines = vec![
-            line_entry(1, 3, "FOO=BAR"),
-            line_entry(2, 3, ""),
-            line_entry(3, 3, "HOGE=HUGA"),
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=BAR" => None,
+            "" => None,
+            "HOGE=HUGA" => None,
         ];
-        let mut fixing_lines = lines.clone();
 
-        assert_eq!(Some(0), fixer.fix_warnings(warnings, &mut fixing_lines));
-        assert_eq!(lines, fixing_lines);
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(0), fix_count);
+        assert_eq!(vec!["FOO=BAR", "", "HOGE=HUGA"], fixed_lines);
     }
 
     #[test]
     fn fix_one_extra_blank_line_test() {
         let mut fixer = ExtraBlankLineFixer::default();
 
-        let line1 = line_entry(1, 4, "FOO=BAR");
-        let line2 = line_entry(2, 4, "");
-        let line3 = line_entry(3, 4, "");
-        let line4 = line_entry(4, 4, "HOGE=HUGA");
-        let mut warning =
-            Warning::new(line3.clone(), "ExtraBlankLine", "Extra blank line detected");
-        let warnings = vec![&mut warning];
-        let mut lines = vec![line1, line2, line3, line4];
-        assert_eq!(Some(1), fixer.fix_warnings(warnings, &mut lines));
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=BAR" => None,
+            "" => None,
+            "" => Some(("ExtraBlankLine", "Extra blank line detected")),
+            "HOGE=HUGA" => None,
+        ];
+
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(vec!["FOO=BAR", "", "HOGE=HUGA"], fixed_lines);
     }
 
     #[test]
     fn fix_multiple_blank_lines_test() {
         let mut fixer = ExtraBlankLineFixer::default();
 
-        let line1 = line_entry(1, 5, "FOO=BAR");
-        let line2 = line_entry(2, 5, "");
-        let line3 = line_entry(3, 5, "");
-        let line4 = line_entry(4, 5, "");
-        let line5 = line_entry(5, 5, "HOGE=HUGA");
-        let mut warning1 =
-            Warning::new(line3.clone(), "ExtraBlankLine", "Extra blank line detected");
-        let mut warning2 =
-            Warning::new(line4.clone(), "ExtraBlankLine", "Extra blank line detected");
-        let warnings = vec![&mut warning1, &mut warning2];
-        let mut lines = vec![line1, line2, line3, line4, line5];
-        assert_eq!(Some(2), fixer.fix_warnings(warnings, &mut lines));
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=BAR" => None,
+            "" => None,
+            "" => Some(("ExtraBlankLine", "Extra blank line detected")),
+            "" => Some(("ExtraBlankLine", "Extra blank line detected")),
+            "HOGE=HUGA" => None,
+        ];
+
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(2), fix_count);
+        assert_eq!(vec!["FOO=BAR", "", "HOGE=HUGA"], fixed_lines);
     }
 }

--- a/src/fixes/incorrect_delimiter.rs
+++ b/src/fixes/incorrect_delimiter.rs
@@ -36,8 +36,6 @@ impl Fix for IncorrectDelimiterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -68,14 +66,18 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = IncorrectDelimiterFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "RAILS-ENV=development" => Some(("IncorrectDelimiter", "The RAILS-ENV key has has an incorrect delimter")),
-            "RAILS_ENV=true" => None,
-            "\n" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut IncorrectDelimiterFixer::default(),
+            vec![
+                TestLine::new("RAILS-ENV=development").warning(
+                    "IncorrectDelimiter",
+                    "The RAILS-ENV key has has an incorrect delimter",
+                ),
+                TestLine::new("RAILS_ENV=true"),
+                TestLine::new("\n"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(

--- a/src/fixes/incorrect_delimiter.rs
+++ b/src/fixes/incorrect_delimiter.rs
@@ -36,6 +36,8 @@ impl Fix for IncorrectDelimiterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -67,18 +69,18 @@ mod tests {
     #[test]
     fn fix_warnings_test() {
         let mut fixer = IncorrectDelimiterFixer::default();
-        let mut lines = vec![
-            line_entry(1, 3, "RAILS-ENV=development"),
-            line_entry(2, 3, "RAILS_ENV=true"),
-            blank_line_entry(3, 3),
-        ];
-        let mut warning = Warning::new(
-            lines[0].clone(),
-            "IncorrectDelimiter",
-            "The RAILS-ENV key has has an incorrect delimter",
-        );
 
-        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
-        assert_eq!("RAILS_ENV=development", lines[0].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "RAILS-ENV=development" => Some(("IncorrectDelimiter", "The RAILS-ENV key has has an incorrect delimter")),
+            "RAILS_ENV=true" => None,
+            "\n" => None,
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(
+            vec!["RAILS_ENV=development", "RAILS_ENV=true", "\n"],
+            fixed_lines
+        );
     }
 }

--- a/src/fixes/key_without_value.rs
+++ b/src/fixes/key_without_value.rs
@@ -29,8 +29,6 @@ impl Fix for KeyWithoutValueFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -43,15 +41,18 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = KeyWithoutValueFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO" => Some(("KeyWithoutValue","The FOO key should be with a value or have an equal sign")),
-            "Z=Y" => None,
-            "\n" => None,
-        ];
-
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut KeyWithoutValueFixer::default(),
+            vec![
+                TestLine::new("FOO").warning(
+                    "KeyWithoutValue",
+                    "The FOO key should be with a value or have an equal sign",
+                ),
+                TestLine::new("Z=Y"),
+                TestLine::new("\n"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(vec!["FOO=", "Z=Y", "\n"], fixed_lines);

--- a/src/fixes/key_without_value.rs
+++ b/src/fixes/key_without_value.rs
@@ -29,6 +29,8 @@ impl Fix for KeyWithoutValueFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -42,18 +44,16 @@ mod tests {
     #[test]
     fn fix_warnings_test() {
         let mut fixer = KeyWithoutValueFixer::default();
-        let mut lines = vec![
-            line_entry(1, 3, "FOO"),
-            line_entry(2, 3, "Z=Y"),
-            blank_line_entry(3, 3),
-        ];
-        let mut warning = Warning::new(
-            lines[0].clone(),
-            "KeyWithoutValue",
-            "The FOO key should be with a value or have an equal sign",
-        );
 
-        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
-        assert_eq!("FOO=", lines[0].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "FOO" => Some(("KeyWithoutValue","The FOO key should be with a value or have an equal sign")),
+            "Z=Y" => None,
+            "\n" => None,
+        ];
+
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(vec!["FOO=", "Z=Y", "\n"], fixed_lines);
     }
 }

--- a/src/fixes/leading_character.rs
+++ b/src/fixes/leading_character.rs
@@ -33,8 +33,6 @@ impl Fix for LeadingCharacterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_leading_dot() {
@@ -101,22 +99,22 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = LeadingCharacterFixer::default();
-
         let warning_name = "LeadingCharacter";
         let message = "Invalid leading character detected";
 
-        let (lines, warnings) = lines_and_warnings![
-            ".FOO=BAR" => Some((warning_name, message)),
-            " Z=Y" => Some((warning_name, message)),
-            "*BAR=BAZ" => Some((warning_name, message)),
-            "1QUX=QUUX" => Some((warning_name, message)),
-            "_QUUX=FOOBAR" => None,
-            "KEY=VALUE" => None,
-            "\n" => None,
-        ];
-
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut LeadingCharacterFixer::default(),
+            vec![
+                TestLine::new(".FOO=BAR").warning(warning_name, message),
+                TestLine::new(" Z=Y").warning(warning_name, message),
+                TestLine::new("*BAR=BAZ").warning(warning_name, message),
+                TestLine::new("1QUX=QUUX").warning(warning_name, message),
+                TestLine::new("_QUUX=FOOBAR"),
+                TestLine::new("KEY=VALUE"),
+                TestLine::new("\n"),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(4), fix_count);
         assert_eq!(

--- a/src/fixes/lowercase_key.rs
+++ b/src/fixes/lowercase_key.rs
@@ -31,6 +31,8 @@ impl Fix for LowercaseKeyFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -44,18 +46,15 @@ mod tests {
     #[test]
     fn fix_warnings_test() {
         let mut fixer = LowercaseKeyFixer::default();
-        let mut lines = vec![
-            line_entry(1, 3, "foO=BAR"),
-            line_entry(2, 3, "Z=Y"),
-            blank_line_entry(3, 3),
-        ];
-        let mut warning = Warning::new(
-            lines[0].clone(),
-            "LowercaseKey",
-            String::from("The FOO key should be in uppercase"),
-        );
 
-        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
-        assert_eq!("FOO=BAR", lines[0].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "foO=BAR" => Some(("LowercaseKey","The FOO key should be in uppercase")),
+            "Z=Y" => None,
+            "" => None,
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(vec!["FOO=BAR", "Z=Y", ""], fixed_lines);
     }
 }

--- a/src/fixes/lowercase_key.rs
+++ b/src/fixes/lowercase_key.rs
@@ -31,8 +31,6 @@ impl Fix for LowercaseKeyFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -45,14 +43,16 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = LowercaseKeyFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "foO=BAR" => Some(("LowercaseKey","The FOO key should be in uppercase")),
-            "Z=Y" => None,
-            "" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut LowercaseKeyFixer::default(),
+            vec![
+                TestLine::new("foO=BAR")
+                    .warning("LowercaseKey", "The FOO key should be in uppercase"),
+                TestLine::new("Z=Y"),
+                TestLine::new(""),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(vec!["FOO=BAR", "Z=Y", ""], fixed_lines);

--- a/src/fixes/quote_character.rs
+++ b/src/fixes/quote_character.rs
@@ -32,8 +32,6 @@ impl Fix for QuoteCharacterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -46,14 +44,16 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = QuoteCharacterFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=\"bar\'\"" => Some(("QuoteCharacter", "The value has quote characters (\', \")")),
-            "Z=Y" => None,
-            "" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut QuoteCharacterFixer::default(),
+            vec![
+                TestLine::new("FOO=\"bar\'\"")
+                    .warning("QuoteCharacter", "The value has quote characters (\', \")"),
+                TestLine::new("Z=Y"),
+                TestLine::new(""),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(vec!["FOO=bar", "Z=Y", ""], fixed_lines);

--- a/src/fixes/quote_character.rs
+++ b/src/fixes/quote_character.rs
@@ -32,6 +32,8 @@ impl Fix for QuoteCharacterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -45,18 +47,15 @@ mod tests {
     #[test]
     fn fix_warnings_test() {
         let mut fixer = QuoteCharacterFixer::default();
-        let mut lines = vec![
-            line_entry(1, 3, "FOO=\"bar\'\""),
-            line_entry(2, 3, "Z=Y"),
-            blank_line_entry(3, 3),
-        ];
-        let mut warning = Warning::new(
-            lines[0].clone(),
-            "QuoteCharacter",
-            "The value has quote characters (\', \")",
-        );
 
-        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
-        assert_eq!("FOO=bar", lines[0].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=\"bar\'\"" => Some(("QuoteCharacter", "The value has quote characters (\', \")")),
+            "Z=Y" => None,
+            "" => None,
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(vec!["FOO=bar", "Z=Y", ""], fixed_lines);
     }
 }

--- a/src/fixes/space_character.rs
+++ b/src/fixes/space_character.rs
@@ -31,8 +31,6 @@ impl Fix for SpaceCharacterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -54,14 +52,17 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = SpaceCharacterFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO= BAR" => Some(("SpaceCharacter","The line has spaces around equal sign")),
-            "Z =Y" => Some(("SpaceCharacter","The line has spaces around equal sign")),
-            "" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut SpaceCharacterFixer::default(),
+            vec![
+                TestLine::new("FOO= BAR")
+                    .warning("SpaceCharacter", "The line has spaces around equal sign"),
+                TestLine::new("Z =Y")
+                    .warning("SpaceCharacter", "The line has spaces around equal sign"),
+                TestLine::new(""),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(2), fix_count);
         assert_eq!(vec!["FOO=BAR", "Z=Y", ""], fixed_lines);

--- a/src/fixes/space_character.rs
+++ b/src/fixes/space_character.rs
@@ -31,6 +31,8 @@ impl Fix for SpaceCharacterFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -53,29 +55,15 @@ mod tests {
     #[test]
     fn fix_warnings_test() {
         let mut fixer = SpaceCharacterFixer::default();
-        let mut lines = vec![
-            line_entry(1, 3, "FOO= BAR"),
-            line_entry(2, 3, "Z =Y"),
-            blank_line_entry(3, 3),
-        ];
-        let mut warnings = vec![
-            Warning::new(
-                lines[0].clone(),
-                "SpaceCharacter",
-                "The line has spaces around equal sign",
-            ),
-            Warning::new(
-                lines[1].clone(),
-                "SpaceCharacter",
-                "The line has spaces around equal sign",
-            ),
-        ];
 
-        assert_eq!(
-            Some(2),
-            fixer.fix_warnings(warnings.iter_mut().collect(), &mut lines)
-        );
-        assert_eq!("FOO=BAR", lines[0].raw_string);
-        assert_eq!("Z=Y", lines[1].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "FOO= BAR" => Some(("SpaceCharacter","The line has spaces around equal sign")),
+            "Z =Y" => Some(("SpaceCharacter","The line has spaces around equal sign")),
+            "" => None,
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(2), fix_count);
+        assert_eq!(vec!["FOO=BAR", "Z=Y", ""], fixed_lines);
     }
 }

--- a/src/fixes/trailing_whitespace.rs
+++ b/src/fixes/trailing_whitespace.rs
@@ -29,8 +29,6 @@ impl Fix for TrailingWhitespaceFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
-    use crate::fixes::run_fix_warnings;
-    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -43,14 +41,16 @@ mod tests {
 
     #[test]
     fn fix_warnings_test() {
-        let mut fixer = TrailingWhitespaceFixer::default();
-
-        let (lines, warnings) = lines_and_warnings![
-            "FOO=BAR " => Some(("TrailingWhitespace","Trailing whitespace detected")),
-            "Z=Y" => None,
-            "" => None,
-        ];
-        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+        let (fix_count, fixed_lines) = run_fix_warnings(
+            &mut TrailingWhitespaceFixer::default(),
+            vec![
+                TestLine::new("FOO=BAR ")
+                    .warning("TrailingWhitespace", "Trailing whitespace detected"),
+                TestLine::new("Z=Y"),
+                TestLine::new(""),
+            ]
+            .into(),
+        );
 
         assert_eq!(Some(1), fix_count);
         assert_eq!(vec!["FOO=BAR", "Z=Y", ""], fixed_lines);

--- a/src/fixes/trailing_whitespace.rs
+++ b/src/fixes/trailing_whitespace.rs
@@ -29,6 +29,8 @@ impl Fix for TrailingWhitespaceFixer<'_> {
 mod tests {
     use super::*;
     use crate::common::tests::*;
+    use crate::fixes::run_fix_warnings;
+    use crate::lines_and_warnings;
 
     #[test]
     fn fix_line_test() {
@@ -42,18 +44,15 @@ mod tests {
     #[test]
     fn fix_warnings_test() {
         let mut fixer = TrailingWhitespaceFixer::default();
-        let mut lines = vec![
-            line_entry(1, 3, "FOO=BAR "),
-            line_entry(2, 3, "Z=Y"),
-            blank_line_entry(3, 3),
-        ];
-        let mut warning = Warning::new(
-            lines[0].clone(),
-            "TrailingWhitespace",
-            "Trailing whitespace detected",
-        );
 
-        assert_eq!(Some(1), fixer.fix_warnings(vec![&mut warning], &mut lines));
-        assert_eq!("FOO=BAR", lines[0].raw_string);
+        let (lines, warnings) = lines_and_warnings![
+            "FOO=BAR " => Some(("TrailingWhitespace","Trailing whitespace detected")),
+            "Z=Y" => None,
+            "" => None,
+        ];
+        let (fix_count, fixed_lines) = run_fix_warnings(&mut fixer, lines, warnings);
+
+        assert_eq!(Some(1), fix_count);
+        assert_eq!(vec!["FOO=BAR", "Z=Y", ""], fixed_lines);
     }
 }


### PR DESCRIPTION
There are two major refactoring done in this PR, both for the unit tests in fixers. This PR is also a preparation for #410 
1.  Introduced a new macro `lines_and_warnings` which makes it easier to define input for fixer tests. Fixers work with lines and warnings, and so the tests require to prepare a `Vec<LineEntry>` and a `Vec<Warning>`. Using this macro, we avoid writing boilerplate code. It also makes it easier to change `LineEntry` or `Warning` interface in future (which will happen in #410).
2. Added a new generic function `run_fix_warnings`, which takes any `Fix` object, and runs its `fix_warnings` over the lines and warnings passed in. This abstracts away the details of how lines and warnings are passed to `fix_warnings`. Towards that, it takes the ownership of both lines and warnings vector, so that they can be morphed into appropriate input for `fix_warnings` call. Fix for #410 would require changing the signature of `fix_warnings`.

NOTE: I haven't committed changes converting unordered_key tests to use new `lines_and_warnings` macro, as it has total 22 tests. I'd do it once I get your feedback on this new macro.
<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
