### PR TITLE
Avoid making a copy of LineEntrys for warnings

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -14,7 +14,7 @@ mod unordered_key;
 
 // This trait is used for checks which needs to know of only a single line
 trait Check {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning>;
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>>;
     fn name(&self) -> &str;
     fn skip_comments(&self) -> bool {
         true
@@ -45,7 +45,7 @@ pub fn available_check_names() -> Vec<String> {
         .collect()
 }
 
-pub fn run(lines: &[LineEntry], skip_checks: &[&str]) -> Vec<Warning> {
+pub fn run<'l>(lines: &'l [LineEntry], skip_checks: &[&str]) -> Vec<Warning<'l>> {
     let mut checks = checklist();
 
     // Skip checks with the --skip argument (globally)

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -25,11 +25,11 @@ impl Default for DuplicatedKeyChecker<'_> {
 }
 
 impl Check for DuplicatedKeyChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let key = line.get_key()?;
 
         if self.keys.contains(key) {
-            return Some(Warning::new(line.clone(), self.name(), self.message(&key)));
+            return Some(Warning::new(line, self.name(), self.message(&key)));
         }
 
         self.keys.insert(key.to_string());

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -22,9 +22,9 @@ impl EndingBlankLineChecker<'_> {
 }
 
 impl Check for EndingBlankLineChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         if line.is_last_line() && !line.raw_string.ends_with(LF) {
-            Some(Warning::new(line.clone(), self.name(), self.message()))
+            Some(Warning::new(line, self.name(), self.message()))
         } else {
             None
         }

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -24,7 +24,7 @@ impl Default for ExtraBlankLineChecker<'_> {
 }
 
 impl Check for ExtraBlankLineChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         if !line.is_empty() {
             return None;
         }
@@ -36,7 +36,7 @@ impl Check for ExtraBlankLineChecker<'_> {
         self.last_blank_number = Some(line.number);
 
         if is_extra {
-            return Some(Warning::new(line.clone(), self.name(), self.message()));
+            return Some(Warning::new(line, self.name(), self.message()));
         }
 
         None

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -22,7 +22,7 @@ impl Default for IncorrectDelimiterChecker<'_> {
 }
 
 impl Check for IncorrectDelimiterChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let key = line.get_key()?;
 
         // delimiters occur /between/ characters, not as the initial character, so we should
@@ -34,7 +34,7 @@ impl Check for IncorrectDelimiterChecker<'_> {
             .chars()
             .any(|c| !c.is_alphanumeric() && c != '_')
         {
-            return Some(Warning::new(line.clone(), self.name(), self.message(&key)));
+            return Some(Warning::new(line, self.name(), self.message(&key)));
         }
 
         None

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -22,10 +22,10 @@ impl KeyWithoutValueChecker<'_> {
 }
 
 impl Check for KeyWithoutValueChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         if !(line.is_empty() || line.raw_string.contains('=')) {
             Some(Warning::new(
-                line.clone(),
+                line,
                 self.name(),
                 self.message(line.get_key().unwrap_or(&line.raw_string)),
             ))

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -22,7 +22,7 @@ impl LeadingCharacterChecker<'_> {
 }
 
 impl Check for LeadingCharacterChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         if line.is_empty()
             || line
                 .raw_string
@@ -30,7 +30,7 @@ impl Check for LeadingCharacterChecker<'_> {
         {
             None
         } else {
-            Some(Warning::new(line.clone(), self.name(), self.message()))
+            Some(Warning::new(line, self.name(), self.message()))
         }
     }
 

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -16,12 +16,12 @@ impl Default for LowercaseKeyChecker<'_> {
 }
 
 impl Check for LowercaseKeyChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let key = line.get_key()?;
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line.clone(), self.name(), self.message(&key)))
+            Some(Warning::new(line, self.name(), self.message(&key)))
         }
     }
 

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -22,14 +22,14 @@ impl Default for QuoteCharacterChecker<'_> {
 }
 
 impl Check for QuoteCharacterChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let val = line.get_value()?;
         if val.contains("\\n") || val.contains(char::is_whitespace) {
             return None;
         }
 
         if val.contains('\"') || val.contains('\'') {
-            Some(Warning::new(line.clone(), self.name(), self.message()))
+            Some(Warning::new(line, self.name(), self.message()))
         } else {
             None
         }

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -22,12 +22,12 @@ impl Default for SpaceCharacterChecker<'_> {
 }
 
 impl Check for SpaceCharacterChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let line_splitted = line.raw_string.split('=').collect::<Vec<&str>>();
 
         if let [key, value] = &line_splitted[..] {
             if key.ends_with(' ') || value.starts_with(' ') {
-                return Some(Warning::new(line.clone(), self.name(), self.message()));
+                return Some(Warning::new(line, self.name(), self.message()));
             }
         }
 

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -22,11 +22,11 @@ impl Default for TrailingWhitespaceChecker<'_> {
 }
 
 impl Check for TrailingWhitespaceChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let raw_string = &line.raw_string;
 
         if raw_string.ends_with(' ') {
-            return Some(Warning::new(line.clone(), self.name, self.message()));
+            return Some(Warning::new(line, self.name, self.message()));
         }
 
         None

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -26,7 +26,7 @@ impl Default for UnorderedKeyChecker<'_> {
 }
 
 impl Check for UnorderedKeyChecker<'_> {
-    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+    fn run<'l>(&mut self, line: &'l LineEntry) -> Option<Warning<'l>> {
         let has_substitution_in_group = line
             .get_substitution_keys()
             .iter()
@@ -51,7 +51,7 @@ impl Check for UnorderedKeyChecker<'_> {
         let another_key = sorted_keys.iter().skip_while(|&s| s != key).nth(1)?;
 
         Some(Warning::new(
-            line.clone(),
+            line,
             self.name(),
             self.message(&key, &another_key),
         ))

--- a/src/common/warning.rs
+++ b/src/common/warning.rs
@@ -3,14 +3,18 @@ use std::fmt;
 use crate::common::*;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Warning {
+pub struct Warning<'l> {
     pub check_name: String,
-    line: LineEntry,
+    line: &'l LineEntry,
     message: String,
 }
 
-impl Warning {
-    pub fn new(line: LineEntry, check_name: impl Into<String>, message: impl Into<String>) -> Self {
+impl<'l> Warning<'l> {
+    pub fn new(
+        line: &'l LineEntry,
+        check_name: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
         let check_name = check_name.into();
         let message = message.into();
         Self {
@@ -25,7 +29,7 @@ impl Warning {
     }
 }
 
-impl fmt::Display for Warning {
+impl<'l> fmt::Display for Warning<'l> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/src/fixes/duplicated_key.rs
+++ b/src/fixes/duplicated_key.rs
@@ -21,7 +21,7 @@ impl Fix for DuplicatedKeyFixer<'_> {
 
     fn fix_warnings(
         &mut self,
-        warnings: Vec<&mut Warning>,
+        warning_lines: &[usize],
         lines: &mut Vec<LineEntry>,
     ) -> Option<usize> {
         let mut keys = HashSet::with_capacity(lines.len());
@@ -46,7 +46,7 @@ impl Fix for DuplicatedKeyFixer<'_> {
             }
         }
 
-        Some(warnings.len())
+        Some(warning_lines.len())
     }
 
     fn fix_line(&mut self, line: &mut LineEntry) -> Option<()> {

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -20,7 +20,7 @@ impl Fix for EndingBlankLineFixer<'_> {
 
     fn fix_warnings(
         &mut self,
-        _warnings: Vec<&mut Warning>,
+        _warning_lines: &[usize],
         lines: &mut Vec<LineEntry>,
     ) -> Option<usize> {
         let last_line = lines.last()?;

--- a/src/fixes/unordered_key.rs
+++ b/src/fixes/unordered_key.rs
@@ -35,7 +35,7 @@ impl Fix for UnorderedKeyFixer<'_> {
 
     fn fix_warnings(
         &mut self,
-        warnings: Vec<&mut Warning>,
+        warning_lines: &[usize],
         lines: &mut Vec<LineEntry>,
     ) -> Option<usize> {
         // We find all sorting groups and sort them
@@ -102,7 +102,7 @@ impl Fix for UnorderedKeyFixer<'_> {
             }
         }
 
-        Some(warnings.len())
+        Some(warning_lines.len())
     }
 
     fn is_mandatory(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
         let mut lines = get_line_entries(&fe, strings);
         let result = checks::run(&lines, &skip_checks);
 
+        output.print_warnings(&result, index);
+        warnings_count += result.len();
+
         // populate a map of warning name to line numbers where the warning is reported.
         let mut warning_to_lines: HashMap<String, Vec<usize>> = HashMap::new();
         for warning in &result {
@@ -90,9 +93,6 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
             // write corrected file
             fs_utils::write_file(&fe.path, lines)?;
         }
-
-        output.print_warnings(&result, index);
-        warnings_count += result.len();
     }
 
     output.print_total(warnings_count);


### PR DESCRIPTION
This is a _proof of concept_ for the fix for #410 

Store a borrowed reference instead of a copy of `LineEntry` inside `Warning`.

First, refactored fixers to stop taking mutable `Warning` objects. Instead, they only talke line numbers where a fix is needed. Changed `fixes::run` to take a map of warning name to line numbers, instead of mutable `Warning`s. The caller `lib::fix` prepares this map by going over the warnings generated by the checker, and moves it over to `fixes::run`.

Updated `Warning` definition to store a borrowed reference. Update `Check` and its implementations to use explicit lifetimes for references passed to`run`.

NOTE: One side effect of this change is that warnings will be printed before backup path is printed.

With these changes, `cargo build` compiles fine. `cargo test` would require refactoring tests first, which would be simpler after #421 and #422 are merged.

#### ✔ Checklist:
- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
