### PR TITLE
build: add aarch64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,25 @@ jobs:
           tar -czf dotenv-linter-linux-x86_64.tar.gz dotenv-linter
           rm dotenv-linter
 
+          rustup target add aarch64-unknown-linux-gnu
+          cargo build --release --target aarch64-unknown-linux-gnu
+          mv target/aarch64-unknown-linux-gnu/release/dotenv-linter ./dotenv-linter
+          chmod +x dotenv-linter
+          tar -czf dotenv-linter-linux-aarch64.tar.gz dotenv-linter
+          rm dotenv-linter
+
           rustup target add x86_64-unknown-linux-musl
           cargo build --release --target x86_64-unknown-linux-musl
           mv target/x86_64-unknown-linux-musl/release/dotenv-linter ./dotenv-linter
           chmod +x dotenv-linter
           tar -czf dotenv-linter-alpine-x86_64.tar.gz dotenv-linter
+          rm dotenv-linter
+
+          rustup target add aarch64-unknown-linux-musl
+          cargo build --release --target aarch64-unknown-linux-musl
+          mv target/aarch64-unknown-linux-musl/release/dotenv-linter ./dotenv-linter
+          chmod +x dotenv-linter
+          tar -czf dotenv-linter-alpine-aarch64.tar.gz dotenv-linter
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
@@ -47,6 +61,13 @@ jobs:
           mv target/x86_64-apple-darwin/release/dotenv-linter ./dotenv-linter
           chmod +x dotenv-linter
           tar -czf dotenv-linter-darwin-x86_64.tar.gz dotenv-linter
+          rm dotenv-linter
+
+          rustup target add aarch64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
+          mv target/aarch64-apple-darwin/release/dotenv-linter ./dotenv-linter
+          chmod +x dotenv-linter
+          tar -czf dotenv-linter-darwin-arm64.tar.gz dotenv-linter
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
@@ -126,6 +147,10 @@ jobs:
         run: |
           cargo build --release --target x86_64-pc-windows-msvc
           Compress-Archive -Path ".\target\x86_64-pc-windows-msvc\release\dotenv-linter.exe" -DestinationPath ".\dotenv-linter-win-x64.zip"
+
+          rustup target add aarch64-pc-windows-msvc
+          cargo build --release --target aarch64-pc-windows-msvc
+          Compress-Archive -Path ".\target\aarch64-pc-windows-msvc\release\dotenv-linter.exe" -DestinationPath ".\dotenv-linter-win-aarch64.zip"
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- `aarch64` support (mac, linux, win) [#436](https://github.com/dotenv-linter/dotenv-linter/pull/436) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
 - Fix clippy warnings [#437](https://github.com/dotenv-linter/dotenv-linter/pull/437) ([@mgrachev](https://github.com/mgrachev))

--- a/install.sh
+++ b/install.sh
@@ -109,8 +109,8 @@ get_architecture() {
     _cputype="$(uname -m)"
     _clibtype="gnu"
 
-    if [ "$_cputype" != "x86_64" ]; then
-	    err "Error: Unsupported architecture $_cputype. Only x86_64 binaries are available."
+    if [ "$_cputype" != "x86_64" ] && [ "$_cputype" != "aarch64" ] && [ "$_cputype" != "arm64" ]; then
+	    err "Error: Unsupported architecture $_cputype. Only 'x86_64' and 'aarch64/arm64' binaries are available."
     fi
 
     if [ "$_ostype" = "Linux" ]; then
@@ -136,7 +136,9 @@ get_architecture() {
 
         CYGWIN*|MINGW32*|MSYS*|MINGW*) # windows systems
             _ostype=win
-            _cputype="x64"
+            if [ "$_cputype" = "x86_64" ]; then
+                _cputype="x64"
+            fi
         ;;
 
         *)


### PR DESCRIPTION
`aarch64` support for mac, linux, windows
These might be useful changes because aarch64 is gaining popularity.
Closes #435 

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
