### PR TITLE
Add type alias for `Result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Add type alias for `Result` [#445](https://github.com/dotenv-linter/dotenv-linter/pull/445) ([@mgrachev](https://github.com/mgrachev))
 - Change edition to 2021 [#444](https://github.com/dotenv-linter/dotenv-linter/pull/444) ([@mgrachev](https://github.com/mgrachev))
 - Display a message on installation error [#443](https://github.com/dotenv-linter/dotenv-linter/pull/443) ([@mgrachev](https://github.com/mgrachev))
 

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -1,5 +1,5 @@
 use crate::common::{FileEntry, LineEntry};
-use std::error::Error;
+use crate::Result;
 use std::fs::{copy, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -46,7 +46,7 @@ pub fn write_file(path: &Path, lines: Vec<LineEntry>) -> io::Result<()> {
     Ok(())
 }
 
-pub fn backup_file(fe: &FileEntry) -> Result<PathBuf, Box<dyn Error>> {
+pub fn backup_file(fe: &FileEntry) -> Result<PathBuf> {
     let timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_secs();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
-use crate::common::*;
-use std::collections::BTreeMap;
-use std::collections::HashSet;
-use std::error::Error;
+use common::*;
+use lint_kind::LintKind;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::str::FromStr;
+
+pub use checks::available_check_names;
 
 mod checks;
 pub mod cli;
@@ -12,12 +14,9 @@ mod fixes;
 mod fs_utils;
 mod lint_kind;
 
-pub use checks::available_check_names;
-use common::CompareWarning;
-use lint_kind::LintKind;
-use std::rc::Rc;
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-pub fn check(args: &clap::ArgMatches, current_dir: &Path) -> Result<usize, Box<dyn Error>> {
+pub fn check(args: &clap::ArgMatches, current_dir: &Path) -> Result<usize> {
     let lines_map = get_lines(args, current_dir);
     let output = CheckOutput::new(args.is_present("quiet"), lines_map.len());
 
@@ -55,7 +54,7 @@ pub fn check(args: &clap::ArgMatches, current_dir: &Path) -> Result<usize, Box<d
     Ok(warnings_count)
 }
 
-pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Error>> {
+pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<()> {
     let mut warnings_count = 0;
     let lines_map = get_lines(args, current_dir);
     let output = FixOutput::new(args.is_present("quiet"), lines_map.len());
@@ -109,10 +108,7 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<(), Box<dyn Er
 }
 
 // Compares if different environment files contains the same variables and returns warnings if not
-pub fn compare(
-    args: &clap::ArgMatches,
-    current_dir: &Path,
-) -> Result<Vec<CompareWarning>, Box<dyn Error>> {
+pub fn compare(args: &clap::ArgMatches, current_dir: &Path) -> Result<Vec<CompareWarning>> {
     let mut all_keys: HashSet<String> = HashSet::new();
     let lines_map = get_lines(args, current_dir);
     let output = CompareOutput::new(args.is_present("quiet"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::error::Error;
+use dotenv_linter::Result;
 use std::{env, process};
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     #[cfg(windows)]
     colored::control::set_virtual_terminal(true).ok();
 


### PR DESCRIPTION
A little refactoring of the code.
Moved a repetitive `Box <dyn Error>` into a separate `Result` type.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
