### PR TITLE
Get rid of `Rc<FileEntry>` in `LineEntry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Get rid of `Rc<FileEntry>` in `LineEntry` [#448](https://github.com/dotenv-linter/dotenv-linter/pull/448) ([@mgrachev](https://github.com/mgrachev))
 - Replace `LineEntry` with line number in `Warning` [#447](https://github.com/dotenv-linter/dotenv-linter/pull/447) ([@mgrachev](https://github.com/mgrachev))
 - Tidy up imports [#446](https://github.com/dotenv-linter/dotenv-linter/pull/446) ([@mgrachev](https://github.com/mgrachev))
 - Add type alias for `Result` [#445](https://github.com/dotenv-linter/dotenv-linter/pull/445) ([@mgrachev](https://github.com/mgrachev))

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -21,7 +21,7 @@ impl Default for EndingBlankLineChecker<'_> {
 
 impl Check for EndingBlankLineChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
-        if line.is_last_line() && !line.raw_string.ends_with(LF) {
+        if line.is_last_line && !line.raw_string.ends_with(LF) {
             Some(Warning::new(line.number, self.name(), self.message()))
         } else {
             None

--- a/src/common.rs
+++ b/src/common.rs
@@ -25,9 +25,6 @@ pub fn remove_invalid_leading_chars(string: &str) -> &str {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::path::PathBuf;
-    use std::rc::Rc;
-
     use super::*;
     use crate::checks::Check;
 
@@ -81,27 +78,11 @@ pub(crate) mod tests {
     }
 
     pub fn blank_line_entry(number: usize, total_lines: usize) -> LineEntry {
-        LineEntry::new(
-            number,
-            Rc::new(FileEntry {
-                path: PathBuf::from(".env"),
-                file_name: ".env".to_string(),
-                total_lines,
-            }),
-            "\n",
-        )
+        LineEntry::new(number, "\n", total_lines == number)
     }
 
     pub fn line_entry(number: usize, total_lines: usize, raw_string: &str) -> LineEntry {
-        LineEntry::new(
-            number,
-            Rc::new(FileEntry {
-                path: PathBuf::from(".env"),
-                file_name: ".env".to_string(),
-                total_lines,
-            }),
-            raw_string,
-        )
+        LineEntry::new(number, raw_string, total_lines == number)
     }
 
     #[test]

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -1,27 +1,26 @@
-use std::rc::Rc;
-
-use super::{comment::Comment, FileEntry};
+use super::comment::Comment;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LineEntry {
     pub number: usize,
-    pub file: Rc<FileEntry>,
     pub raw_string: String,
 
     /// Used in ExtraBlankLineFixer
     pub is_deleted: bool,
+    /// Used in EndingBlankLineChecker
+    pub is_last_line: bool,
 }
 
 impl LineEntry {
-    pub fn new<T>(number: usize, file: Rc<FileEntry>, raw_string: T) -> Self
+    pub fn new<T>(number: usize, raw_string: T, is_last_line: bool) -> Self
     where
         T: Into<String>,
     {
         LineEntry {
             number,
-            file,
             raw_string: raw_string.into(),
             is_deleted: false,
+            is_last_line,
         }
     }
 
@@ -68,10 +67,6 @@ impl LineEntry {
             .unwrap_or(trimmed)
     }
 
-    pub fn is_last_line(&self) -> bool {
-        self.file.total_lines == self.number
-    }
-
     pub fn mark_as_deleted(&mut self) {
         self.is_deleted = true;
     }
@@ -86,7 +81,6 @@ impl LineEntry {
         Comment::parse(self.raw_string.as_str())
     }
 
-    #[allow(dead_code)]
     pub fn get_substitution_keys(&self) -> Vec<&str> {
         let mut keys = Vec::new();
 

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -21,8 +21,7 @@ impl Fix for EndingBlankLineFixer {
             return Some(0);
         }
 
-        let file = lines.first()?.file.clone();
-        lines.push(LineEntry::new(lines.len() + 1, file, LF));
+        lines.push(LineEntry::new(lines.len() + 1, LF, true));
 
         Some(1)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use std::str::FromStr;
 
 use crate::common::*;
@@ -42,7 +41,7 @@ pub fn check(args: &clap::ArgMatches, current_dir: &Path) -> Result<usize> {
             .fold(0, |acc, (index, (fe, strings))| {
                 output.print_processing_info(&fe);
 
-                let lines = get_line_entries(&fe, strings);
+                let lines = get_line_entries(strings);
                 let result = checks::run(&lines, &skip_checks);
 
                 output.print_warnings(&fe, &result, index);
@@ -77,7 +76,7 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<()> {
     for (index, (fe, strings)) in lines_map.into_iter().enumerate() {
         output.print_processing_info(&fe);
 
-        let mut lines = get_line_entries(&fe, strings);
+        let mut lines = get_line_entries(strings);
         let result = checks::run(&lines, &skip_checks);
         if result.is_empty() {
             continue;
@@ -125,7 +124,7 @@ pub fn compare(args: &clap::ArgMatches, current_dir: &Path) -> Result<Vec<Compar
     // Create CompareFileType structures for each file
     for (_, (fe, strings)) in lines_map.into_iter().enumerate() {
         output.print_processing_info(&fe);
-        let lines = get_line_entries(&fe, strings);
+        let lines = get_line_entries(strings);
         let mut keys: Vec<String> = Vec::new();
 
         for line in lines {
@@ -235,11 +234,12 @@ fn get_file_paths(
     file_paths
 }
 
-fn get_line_entries(fe: &FileEntry, lines: Vec<String>) -> Vec<LineEntry> {
-    let fe = Rc::new(fe.clone());
+fn get_line_entries(lines: Vec<String>) -> Vec<LineEntry> {
+    let length = lines.len();
+
     lines
         .into_iter()
         .enumerate()
-        .map(|(index, line)| LineEntry::new(index + 1, fe.clone(), line))
+        .map(|(index, line)| LineEntry::new(index + 1, line, length == (index + 1)))
         .collect()
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
