### PR TITLE
feat: add support for multi-line single-quoted values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # IDEs
 /.idea/
+/.vscode/
+/.history/
 
 # Environment Files
 *.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Support of single-quoted multiline values [#450](https://github.com/dotenv-linter/dotenv-linter/pull/450) ([@DDtKey](https://github.com/DDtKey))
 
 ### 🔧 Changed
 - Get rid of `Rc<FileEntry>` in `LineEntry` [#448](https://github.com/dotenv-linter/dotenv-linter/pull/448) ([@mgrachev](https://github.com/mgrachev))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -56,6 +56,9 @@ pub fn run(lines: &[LineEntry], skip_checks: &[LintKind]) -> Vec<Warning> {
     let mut warnings: Vec<Warning> = Vec::new();
 
     for line in lines {
+        if line.is_multiline_value {
+            continue;
+        }
         if let Some(comment) = line.get_control_comment() {
             if comment.is_disabled() {
                 // Disable checks from a comment using the dotenv-linter:off flag

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -56,9 +56,6 @@ pub fn run(lines: &[LineEntry], skip_checks: &[LintKind]) -> Vec<Warning> {
     let mut warnings: Vec<Warning> = Vec::new();
 
     for line in lines {
-        if line.is_multiline_value {
-            continue;
-        }
         if let Some(comment) = line.get_control_comment() {
             if comment.is_disabled() {
                 // Disable checks from a comment using the dotenv-linter:off flag

--- a/src/checks/substitution_key.rs
+++ b/src/checks/substitution_key.rs
@@ -1,5 +1,5 @@
 use super::Check;
-use crate::common::{LineEntry, LintKind, Warning};
+use crate::common::{is_escaped, LineEntry, LintKind, Warning};
 
 pub(crate) struct SubstitutionKeyChecker<'a> {
     template: &'a str,
@@ -25,9 +25,6 @@ impl Check for SubstitutionKeyChecker<'_> {
             Some(value) if !value.starts_with('\'') => value,
             _ => return None,
         };
-
-        let is_escaped =
-            |prefix: &str| prefix.chars().rev().take_while(|ch| *ch == '\\').count() % 2 == 1;
 
         // Checks if keys used in value have both '{' '}' or neither
         while let Some(index) = value.find('$') {

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,6 +23,10 @@ pub fn remove_invalid_leading_chars(string: &str) -> &str {
     string.trim_start_matches(|c: char| !(c.is_alphabetic() || c == '_'))
 }
 
+pub fn is_escaped(prefix: &str) -> bool {
+    prefix.chars().rev().take_while(|ch| *ch == '\\').count() % 2 == 1
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;

--- a/src/common.rs
+++ b/src/common.rs
@@ -97,4 +97,19 @@ pub(crate) mod tests {
         let string = "***FOO-BAR";
         assert_eq!("FOO-BAR", remove_invalid_leading_chars(string));
     }
+
+    #[test]
+    fn is_escaped_value_test() {
+        let escaped = "\\";
+        assert!(is_escaped(escaped));
+
+        let escaped = "\\\\\\";
+        assert!(is_escaped(escaped));
+
+        let non_escaped = "\\\\";
+        assert!(!is_escaped(non_escaped));
+
+        let random_string = "text without escaping";
+        assert!(!is_escaped(random_string));
+    }
 }

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -1,4 +1,4 @@
-use super::comment::Comment;
+use super::{comment::Comment, is_escaped};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LineEntry {
@@ -9,7 +9,6 @@ pub struct LineEntry {
     pub is_deleted: bool,
     /// Used in EndingBlankLineChecker
     pub is_last_line: bool,
-    pub is_multiline_value: bool,
 }
 
 impl LineEntry {
@@ -22,7 +21,6 @@ impl LineEntry {
             raw_string: raw_string.into(),
             is_deleted: false,
             is_last_line,
-            is_multiline_value: false,
         }
     }
 
@@ -90,9 +88,6 @@ impl LineEntry {
             Some(value) if !value.starts_with('\'') => value,
             _ => return keys,
         };
-
-        let is_escaped =
-            |prefix: &str| prefix.chars().rev().take_while(|ch| *ch == '\\').count() % 2 == 1;
 
         if value.starts_with('\"') {
             if value.ends_with('\"') && !is_escaped(&value[..value.len() - 1]) {

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -9,6 +9,7 @@ pub struct LineEntry {
     pub is_deleted: bool,
     /// Used in EndingBlankLineChecker
     pub is_last_line: bool,
+    pub is_multiline_value: bool,
 }
 
 impl LineEntry {
@@ -21,6 +22,7 @@ impl LineEntry {
             raw_string: raw_string.into(),
             is_deleted: false,
             is_last_line,
+            is_multiline_value: false,
         }
     }
 

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -19,7 +19,9 @@ trait Fix {
     fn fix_warnings(&self, warning_lines: &[usize], lines: &mut Vec<LineEntry>) -> Option<usize> {
         let mut count: usize = 0;
         for line_number in warning_lines {
-            let line = lines.get_mut(line_number - 1)?;
+            let line = lines
+                .iter_mut()
+                .find(|entry| entry.number == *line_number)?;
             if self.fix_line(line).is_some() {
                 count += 1;
             }
@@ -143,7 +145,7 @@ mod tests {
             ),
         ];
 
-        assert_eq!(0, run(&mut warnings, &mut lines, &[]));
+        assert_eq!(2, run(&mut warnings, &mut lines, &[]));
     }
 
     #[test]

--- a/src/fixes/substitution_key.rs
+++ b/src/fixes/substitution_key.rs
@@ -1,5 +1,5 @@
 use super::Fix;
-use crate::common::{LineEntry, LintKind};
+use crate::common::{is_escaped, LineEntry, LintKind};
 
 pub(crate) struct SubstitutionKeyFixer {}
 
@@ -20,9 +20,6 @@ impl Fix for SubstitutionKeyFixer {
             .get_value()
             .map(str::trim)
             .filter(|val| !val.starts_with('\''))?;
-
-        let is_escaped =
-            |prefix: &str| prefix.chars().rev().take_while(|ch| *ch == '\\').count() % 2 == 1;
 
         let mut result = String::with_capacity(value.len());
 

--- a/src/fixes/unordered_key.rs
+++ b/src/fixes/unordered_key.rs
@@ -68,7 +68,7 @@ impl Fix for UnorderedKeyFixer {
                 }
 
                 if line.is_empty()
-                    || lines.len() == line.number // Is this the last line?
+                    || lines.len() == i + 1 // Is this the last line?
                     || is_control_comment
                     || has_substitution_variables
                 {
@@ -115,11 +115,7 @@ impl UnorderedKeyFixer {
             }
         });
 
-        slices.sort_by_cached_key(|slice| {
-            // I think, that we should modify get_key() so it will return Option<&str> instead of
-            // Option<String>.
-            slice.last()?.get_key()
-        });
+        slices.sort_by_cached_key(|slice| slice.last()?.get_key());
 
         let sorted_lines: Vec<_> = slices.into_iter().flat_map(|s| s.iter().cloned()).collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,34 +242,47 @@ fn get_line_entries(lines: Vec<String>) -> Vec<LineEntry> {
         .map(|(index, line)| LineEntry::new(index + 1, line, length == (index + 1)))
         .collect();
 
-    // TODO: refactor
+    // TODO: refactor this part
     let mut multiline_ranges: Vec<(usize, usize)> = Vec::new();
     let mut start_number: Option<usize> = None;
 
     // here we find ranges of multi-line values and mark them
-    lines.iter_mut().for_each(|l| {
-        let is_multiline_start = l
+    lines.iter_mut().for_each(|line| {
+        let is_multiline_start = line
             .get_value()
-            .filter(|e| e.starts_with('\'') && !e.ends_with('\''))
+            // .map(|val| val.trim())
+            .filter(|val| {
+                val.starts_with('\'') && (!val.ends_with('\'') || is_escaped(&val[..val.len() - 1]))
+            })
             .is_some();
+
         if start_number.is_none() && is_multiline_start {
-            start_number = Some(l.number);
-        } else if start_number.is_some() {
-            if l.raw_string.ends_with('\'') {
+            start_number = Some(line.number);
+        } else if let Some(start) = start_number {
+            if line.raw_string.ends_with('\'')
+                && !is_escaped(&line.raw_string[..line.raw_string.len() - 1])
+            {
                 // end of multi-line value, add range to vector
-                multiline_ranges.push((start_number.unwrap(), l.number))
-            } else if l.get_value().is_some() {
+                multiline_ranges.push((start, line.number))
+            } else if line.get_value().is_some() {
                 // if next line correct env line - then previous start-line incorrect multi-value
                 start_number = None;
             }
         }
     });
 
-    // set flags here
-    for val in multiline_ranges {
-        lines[val.0 - 1..val.1]
-            .iter_mut()
-            .for_each(|e| e.is_multiline_value = true)
+    // replace multiline value to one line-entry for checking
+    for (start, end) in multiline_ranges {
+        let mut result: String = String::new();
+
+        for i in start - 1..end {
+            let removed_entry = lines.remove(start - 1);
+            result += &removed_entry.raw_string;
+            if i < end - 1 {
+                result += "\n";
+            }
+        }
+        lines.insert(start - 1, LineEntry::new(start, result, length == end));
     }
 
     lines

--- a/tests/fixes/fixtures/complicated.env
+++ b/tests/fixes/fixtures/complicated.env
@@ -71,3 +71,15 @@ VAR_3=1234
 VAR_2=1234
 VAR_1=1234
 ENV24='key56'
+# dotenv-linter:on QuoteCharacter
+
+# multiline values & ordering:
+
+ZOO=BAR
+M_ENV1=   '{
+    "first": 1,
+    "second": 1
+  }'
+ABC=FOO
+M_ENV2 = 'multiline \'escaped\'
+    value'

--- a/tests/fixes/fixtures/complicated.env.golden
+++ b/tests/fixes/fixtures/complicated.env.golden
@@ -69,3 +69,15 @@ VAR_1=1234
 VAR_5=1234
 VAR_6=1234
 VAR_7=1234
+# dotenv-linter:on QuoteCharacter
+
+# multiline values & ordering:
+
+ABC=FOO
+M_ENV1='{
+    "first": 1,
+    "second": 1
+  }'
+M_ENV2='multiline \'escaped\'
+    value'
+ZOO=BAR

--- a/tests/fixes/fixtures/correct.env
+++ b/tests/fixes/fixtures/correct.env
@@ -16,3 +16,9 @@ A_ENV_12=C
 A_ENV_13=D
 A_ENV_14=123
 A_ENV_15=345
+
+# multiline value
+M_ENV1='{
+    "first": 1,
+    "second": 1
+  }'

--- a/tests/fixes/fixtures/correct.env.golden
+++ b/tests/fixes/fixtures/correct.env.golden
@@ -16,3 +16,9 @@ A_ENV_12=C
 A_ENV_13=D
 A_ENV_14=123
 A_ENV_15=345
+
+# multiline value
+M_ENV1='{
+    "first": 1,
+    "second": 1
+  }'

--- a/tests/output/check.rs
+++ b/tests/output/check.rs
@@ -39,9 +39,12 @@ Found 3 problems
 }
 
 #[test]
-fn run_with_valid_multiline_value_test() {
+fn valid_multiline_value_test() {
     let test_dir = TestDir::new();
-    test_dir.create_testfile(".env", "ABC=DEF\nB='bbb\n  BAR'\n");
+    test_dir.create_testfile(
+        ".env",
+        "FOO=bar\nMULTILINE_FOO='{\n\"first\": 1,\n\"second\": 1\n}'\nZAC=baz\n",
+    );
 
     let expected_output = r#"Checking .env
 

--- a/tests/output/check.rs
+++ b/tests/output/check.rs
@@ -39,6 +39,19 @@ Found 3 problems
 }
 
 #[test]
+fn run_with_valid_multiline_value_test() {
+    let test_dir = TestDir::new();
+    test_dir.create_testfile(".env", "ABC=DEF\nB='bbb\n  BAR'\n");
+
+    let expected_output = r#"Checking .env
+
+No problems found
+"#;
+
+    test_dir.test_command_success(expected_output);
+}
+
+#[test]
 fn problems_first_and_last_file() {
     let test_dir = TestDir::new();
     test_dir.create_testfile(".env", "abc=DEF\n");

--- a/tests/output/check.rs
+++ b/tests/output/check.rs
@@ -43,7 +43,7 @@ fn valid_multiline_value_test() {
     let test_dir = TestDir::new();
     test_dir.create_testfile(
         ".env",
-        "FOO=bar\nMULTILINE_FOO='{\n\"first\": 1,\n\"second\": 1\n}'\nZAC=baz\n",
+        "FOO=bar\nMULTILINE_1='{\n\"first\": 1,\n\"second\": 1\n}'\nMULTILINE_2='multiline \\'escaped\\' \n value'\nZAC=baz\n",
     );
 
     let expected_output = r#"Checking .env


### PR DESCRIPTION
Proof of concept for real multi-line value support #442.
~~It's temporary ugly solution, but it works.~~

Currently, I have added support of real multiline single-quoted values.
This implementation allows us to perform all checks on such values, since they are transformed into one `LineEntry`.

@dotenv-linter/core  I suggest to consider this PR and, if approved, add support of multiline  double-quoted values in another pull request (if needed at all) 🤔 

Partially closes #442

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
