### PR TITLE
WIP build: create docker arm64 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Cache cargo registry and target
         uses: actions/cache@v2
         with:
-            path: |
-              ~/.cargo/registry
-              target
-            key: build-linux-${{ steps.toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            target
+          key: build-linux-${{ steps.toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -157,7 +157,7 @@ jobs:
           command: test
           args: --all-features --no-fail-fast
         env:
-          CARGO_INCREMENTAL: '0'
+          CARGO_INCREMENTAL: "0"
           RUSTFLAGS: |
             -Zprofile -Zpanic_abort_tests -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort
       - uses: actions-rs/grcov@v0.1
@@ -283,5 +283,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build
-        run: docker build --target builder .
+        run: docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t dotenvlinter/dotenv-linter .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - '*.*.*'
+      - "*.*.*"
 
 env:
   CARGO_TERM_COLOR: always
@@ -93,11 +93,11 @@ jobs:
           GIT_TAG=$(git describe --tags `git rev-list --tags --max-count=1` | sed "s/v//")
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
 
-          docker build -t dotenvlinter/dotenv-linter:${GIT_TAG} .
-          docker push dotenvlinter/dotenv-linter:${GIT_TAG}
+          # creates a new builder instance and uses it
+          docker buildx create --use
 
-          docker build -t dotenvlinter/dotenv-linter:latest .
-          docker push dotenvlinter/dotenv-linter:latest
+          docker buildx build --push --platform linux/amd64,linux/arm64 -f Dockerfile -t dotenvlinter/dotenv-linter:${GIT_TAG} .
+          docker buildx build --push --platform linux/amd64,linux/arm64 -f Dockerfile -t dotenvlinter/dotenv-linter:latest .
 
   release-crate:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Build docker image for arm64 [#458](https://github.com/dotenv-linter/dotenv-linter/pull/458) ([@mstruebing](https://github.com/mstruebing))
 - Add check for new version [#454](https://github.com/dotenv-linter/dotenv-linter/pull/454) ([@mgrachev](https://github.com/mgrachev))
 - Support of double-quoted multiline values [#453](https://github.com/dotenv-linter/dotenv-linter/pull/453) ([@DDtKey](https://github.com/DDtKey))
 - Support of single-quoted multiline values [#450](https://github.com/dotenv-linter/dotenv-linter/pull/450) ([@DDtKey](https://github.com/DDtKey))


### PR DESCRIPTION
Closes #449

I hope this will work with GH-actions and the ubuntu-latest container.
I used this locally to test some kubernetes stuff on different environments (arm64 and amd64 nodes) and it worked.

> Docker Buildx is included in Docker Desktop and Docker Linux packages when installed using the DEB or RPM packages.

If you want to know more: https://docs.docker.com/buildx/working-with-buildx/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
