### PR TITLE
refactor: skip_checks with use default iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add dependabot [#472](https://github.com/dotenv-linter/dotenv-linter/pull/472) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Refactor skip_checks with use default iterator [#482](https://github.com/dotenv-linter/dotenv-linter/pull/482) ([@shapurid](https://github.com/shapurid))
 - Update `cargo-deny` config [#481](https://github.com/dotenv-linter/dotenv-linter/pull/481) ([@mgrachev](https://github.com/mgrachev))
 - Fix clippy warnings [#480](https://github.com/dotenv-linter/dotenv-linter/pull/480) ([@shapurid](https://github.com/shapurid))
 - Update dependency: [`update-infromer`](https://github.com/mgrachev/update-informer) [#470](https://github.com/dotenv-linter/dotenv-linter/pull/470) ([@mgrachev](https://github.com/mgrachev))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,15 +28,11 @@ pub fn check(args: &clap::ArgMatches, current_dir: &Path) -> Result<usize> {
         return Ok(0);
     }
 
-    let mut skip_checks: Vec<&str> = Vec::new();
-    if let Some(skip) = args.values_of("skip") {
-        skip_checks = skip.collect();
-    }
-
-    let skip_checks = skip_checks
-        .into_iter()
-        .filter_map(|c| LintKind::from_str(c).ok())
-        .collect::<Vec<LintKind>>();
+    let skip_checks: Vec<LintKind> = args
+        .values_of("skip")
+        .unwrap_or_default()
+        .filter_map(|check: &str| LintKind::from_str(check).ok())
+        .collect();
 
     let warnings_count =
         lines_map
@@ -69,14 +65,11 @@ pub fn fix(args: &clap::ArgMatches, current_dir: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let mut skip_checks: Vec<&str> = Vec::new();
-    if let Some(skip) = args.values_of("skip") {
-        skip_checks = skip.collect();
-    }
-    let skip_checks = skip_checks
-        .into_iter()
-        .filter_map(|c| LintKind::from_str(c).ok())
-        .collect::<Vec<LintKind>>();
+    let skip_checks: Vec<LintKind> = args
+        .values_of("skip")
+        .unwrap_or_default()
+        .filter_map(|check: &str| LintKind::from_str(check).ok())
+        .collect();
 
     for (index, (fe, strings)) in lines_map.into_iter().enumerate() {
         output.print_processing_info(&fe);


### PR DESCRIPTION
Hi everyone! I have substituted `Option<Values>` check and empty vector creation with `unwrap_or_default()`, because `Values` is an iterator, and it's default value is an empty iterator.

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
