### PR TITLE
refactor: check ci with all-targets arg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --all-targets
       - name: Cleanup for caching
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add dependabot [#472](https://github.com/dotenv-linter/dotenv-linter/pull/472) ([@mgrachev](https://github.com/mgrachev))
 
 ### 🔧 Changed
+- Refactor check ci with all-targets arg [#488](https://github.com/dotenv-linter/dotenv-linter/pull/488) ([@shapurid](https://github.com/shapurid))
 - Update `clap` [#485](https://github.com/dotenv-linter/dotenv-linter/pull/485) ([@mgrachev](https://github.com/mgrachev))
 - Update `criterion-compare` action [#484](https://github.com/dotenv-linter/dotenv-linter/pull/484) ([@mgrachev](https://github.com/mgrachev))
 - Refactor skip_checks with use default iterator [#482](https://github.com/dotenv-linter/dotenv-linter/pull/482) ([@shapurid](https://github.com/shapurid))

--- a/benches/fix.rs
+++ b/benches/fix.rs
@@ -22,13 +22,11 @@ fn generate_arg_matches(app: &Command, with_backup: bool) -> ArgMatches {
     args_vector.push(simple_fix_path.to_str().expect("path to str"));
 
     // Generate the ArgMatches
-    let matches = app.clone().get_matches_from(args_vector);
-    let matches = matches
+    app.clone()
+        .get_matches_from(args_vector)
         .subcommand_matches("fix")
         .expect("fix command")
-        .to_owned();
-
-    matches
+        .to_owned()
 }
 
 /// Runs the Fix Benchmark

--- a/benches/fix.rs
+++ b/benches/fix.rs
@@ -1,3 +1,4 @@
+use clap::{ArgMatches, Command};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use std::{env, fs};
 use tempfile::tempdir;
@@ -6,7 +7,7 @@ use tempfile::tempdir;
 use gag::Gag;
 
 /// Generates clap::ArgMatches for the fix Benchmarks and Copies the needed temporary Files
-fn generate_arg_matches<'a>(app: &'a clap::App, with_backup: bool) -> clap::ArgMatches<'a> {
+fn generate_arg_matches(app: &Command, with_backup: bool) -> ArgMatches {
     // Prepare the temporary Files
     let temp = tempdir().expect("create tempdir");
     let path = temp.into_path();


### PR DESCRIPTION
Hi everyone! I refactored typehints, lifetimes and `ArgMatches` generation in check bench, and added `--all-targets` flag in check ci.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
