### PR TITLE
feat: Add check for values that require surrounding quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 - Add `stale` action [#483](https://github.com/dotenv-linter/dotenv-linter/pull/483) ([@mgrachev](https://github.com/mgrachev))
 - Add dependabot [#472](https://github.com/dotenv-linter/dotenv-linter/pull/472) ([@mgrachev](https://github.com/mgrachev))
+- Add new check: Value without quotes [#521](https://github.com/dotenv-linter/dotenv-linter/pull/521)([tabfugnic](https://github.com/tabfugnic))
 
 ### 🔧 Changed
 - Update dependency: `update-infromer` [#493](https://github.com/dotenv-linter/dotenv-linter/pull/493) ([@mgrachev](https://github.com/mgrachev))

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -12,6 +12,7 @@ mod space_character;
 mod substitution_key;
 mod trailing_whitespace;
 mod unordered_key;
+mod value_without_quotes;
 
 // This trait is used for checks which needs to know of only a single line
 pub trait Check {
@@ -37,6 +38,7 @@ fn checklist() -> Vec<Box<dyn Check>> {
         Box::new(substitution_key::SubstitutionKeyChecker::default()),
         Box::new(trailing_whitespace::TrailingWhitespaceChecker::default()),
         Box::new(unordered_key::UnorderedKeyChecker::default()),
+        Box::new(value_without_quotes::ValueWithoutQuotesChecker::default()),
     ]
 }
 

--- a/src/checks/value_without_quotes.rs
+++ b/src/checks/value_without_quotes.rs
@@ -1,0 +1,60 @@
+use super::Check;
+use crate::common::{LineEntry, LintKind, Warning};
+
+pub(crate) struct ValueWithoutQuotesChecker<'a> {
+    template: &'a str,
+}
+
+impl ValueWithoutQuotesChecker<'_> {
+    fn message(&self) -> &str {
+        self.template
+    }
+}
+
+impl Default for ValueWithoutQuotesChecker<'_> {
+    fn default() -> Self {
+        Self {
+            template: "This value needs to be surrounded in quotes",
+        }
+    }
+}
+
+impl Check for ValueWithoutQuotesChecker<'_> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
+        let val = line.get_value()?.trim();
+
+        if val.contains(char::is_whitespace)
+            && !(val.starts_with('\'') && val.ends_with('\''))
+            && !(val.starts_with('\"') && val.ends_with('\"'))
+        {
+            Some(Warning::new(line.number, self.name(), self.message()))
+        } else {
+            None
+        }
+    }
+
+    fn name(&self) -> LintKind {
+        LintKind::ValueWithoutQuotes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::tests::check_test;
+
+    const WARNING: &str = "This value needs to be surrounded in quotes";
+
+    #[test]
+    fn value_without_quotes() {
+        check_test(
+            &mut ValueWithoutQuotesChecker::default(),
+            [
+                ("FOO=BAR", None),
+                ("FOO=BAR BAZ", Some(WARNING)),
+                ("FOO=\"BAR BAZ\"", None),
+                ("FOO=\'BAR BAR\'", None),
+            ],
+        );
+    }
+}

--- a/src/common/lint_kind.rs
+++ b/src/common/lint_kind.rs
@@ -14,6 +14,7 @@ pub enum LintKind {
     SubstitutionKey,
     TrailingWhitespace,
     UnorderedKey,
+    ValueWithoutQuotes,
 }
 
 impl FromStr for LintKind {
@@ -33,6 +34,7 @@ impl FromStr for LintKind {
             "SubstitutionKey" => Ok(LintKind::SubstitutionKey),
             "TrailingWhitespace" => Ok(LintKind::TrailingWhitespace),
             "UnorderedKey" => Ok(LintKind::UnorderedKey),
+            "ValueWithoutQuotes" => Ok(LintKind::ValueWithoutQuotes),
             _ => Err(()),
         }
     }

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -12,6 +12,7 @@ mod space_character;
 mod substitution_key;
 mod trailing_whitespace;
 mod unordered_key;
+mod value_without_quotes;
 
 trait Fix {
     fn name(&self) -> LintKind;
@@ -49,6 +50,7 @@ fn fixlist() -> Vec<Box<dyn Fix>> {
         Box::new(space_character::SpaceCharacterFixer::default()),
         Box::new(trailing_whitespace::TrailingWhitespaceFixer::default()),
         Box::new(leading_character::LeadingCharacterFixer::default()),
+        Box::new(value_without_quotes::ValueWithoutQuotesFixer::default()),
         Box::new(quote_character::QuoteCharacterFixer::default()),
         Box::new(incorrect_delimiter::IncorrectDelimiterFixer::default()),
         Box::new(extra_blank_line::ExtraBlankLineFixer::default()),

--- a/src/fixes/value_without_quotes.rs
+++ b/src/fixes/value_without_quotes.rs
@@ -1,0 +1,48 @@
+use super::Fix;
+use crate::common::{LineEntry, LintKind};
+
+#[derive(Default)]
+pub(crate) struct ValueWithoutQuotesFixer {}
+
+impl Fix for ValueWithoutQuotesFixer {
+    fn name(&self) -> LintKind {
+        LintKind::ValueWithoutQuotes
+    }
+
+    fn fix_line(&self, line: &mut LineEntry) -> Option<()> {
+        let pure_val = format!("\"{}\"", line.get_value()?);
+
+        line.raw_string = format!("{}={}", line.get_key()?, pure_val);
+
+        Some(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::tests::*;
+
+    #[test]
+    fn fix_line_test() {
+        let fixer = ValueWithoutQuotesFixer::default();
+        let mut line = line_entry(1, 1, "FOO=bar baz");
+
+        assert_eq!(Some(()), fixer.fix_line(&mut line));
+        assert_eq!("FOO=\"bar baz\"", line.raw_string);
+    }
+
+    #[test]
+    fn fix_warnings_test() {
+        let fixer = ValueWithoutQuotesFixer::default();
+        let mut lines = vec![
+            line_entry(1, 3, "FOO=bar baz"),
+            line_entry(2, 3, "Z=\"Y X\""),
+            blank_line_entry(3, 3),
+        ];
+        let warning_lines = [lines[0].number];
+
+        assert_eq!(Some(1), fixer.fix_warnings(&warning_lines, &mut lines));
+        assert_eq!("FOO=\"bar baz\"", lines[0].raw_string);
+    }
+}

--- a/tests/checks/mod.rs
+++ b/tests/checks/mod.rs
@@ -10,3 +10,4 @@ mod space_character;
 mod substitution_key;
 mod trailing_whitespace;
 mod unordered_key;
+mod value_without_quotes;

--- a/tests/checks/value_without_quotes.rs
+++ b/tests/checks/value_without_quotes.rs
@@ -1,0 +1,58 @@
+use crate::common::*;
+
+#[test]
+fn correct_files() {
+    let contents = vec![
+        "A=\"B B\"\nF=\"BAR B\"\nFOO=\"BAR BAZ\"\n",
+        "A=\"B B\"\r\nF=\"BAR B\"\r\nFOO=\"BAR BAZ\"\r\n",
+        "# comment\nABC=\"DEF GHI\"\n",
+    ];
+
+    for content in contents {
+        let testdir = TestDir::new();
+        let testfile = testdir.create_testfile(".env", content);
+        let args = &[testfile.as_str()];
+
+        let expected_output = check_output(&[(".env", &[])]);
+
+        testdir.test_command_success_with_args(with_default_args(args), expected_output);
+    }
+}
+
+#[test]
+fn incorrect_files() {
+    let contents = vec![
+        "A=\"B B\"\nF=\"BAR B\"\nFOO=BAR BAZ\n",
+        "A=\"B B\"\r\nF=BAR B\r\nFOO=\"BAR BAZ\"\r\n",
+        "# comment\nABC=DEF GHI\n",
+    ];
+    let expected_line_numbers = vec![3, 2, 2];
+
+    for (i, content) in contents.iter().enumerate() {
+        let testdir = TestDir::new();
+        let testfile = testdir.create_testfile(".env", content);
+        let args = &[testfile.as_str()];
+        let expected_output = check_output(&[(
+            ".env",
+            &[format!(
+                ".env:{} ValueWithoutQuotes: This value needs to be surrounded in quotes",
+                expected_line_numbers[i]
+            )
+            .as_str()],
+        )]);
+
+        testdir.test_command_fail_with_args(with_default_args(args), expected_output);
+    }
+}
+
+#[test]
+fn multiline_value() {
+    let content = "FOO=\"new\\nline value\"\n";
+
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", content);
+    let args = &[testfile.as_str()];
+    let expected_output = check_output(&[(".env", &[])]);
+
+    testdir.test_command_success_with_args(with_default_args(args), expected_output);
+}

--- a/tests/fixes/mod.rs
+++ b/tests/fixes/mod.rs
@@ -14,6 +14,7 @@ mod space_character;
 mod substitution_key;
 mod trailing_whitespace;
 mod unordered_key;
+mod value_without_quotes;
 
 #[test]
 fn correct_file() {

--- a/tests/fixes/value_without_quotes.rs
+++ b/tests/fixes/value_without_quotes.rs
@@ -1,0 +1,22 @@
+use crate::common::*;
+
+#[test]
+fn value_without_quotes() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", "ABC=DEF GHI\nFOO=BAR BAZ\n");
+    let expected_output = fix_output(&[(
+        ".env",
+        &[
+            ".env:1 ValueWithoutQuotes: This value needs to be surrounded in quotes",
+            ".env:2 ValueWithoutQuotes: This value needs to be surrounded in quotes",
+        ],
+    )]);
+    testdir.test_command_fix_success(expected_output);
+
+    assert_eq!(
+        testfile.contents().as_str(),
+        "ABC=\"DEF GHI\"\nFOO=\"BAR BAZ\"\n"
+    );
+
+    testdir.close();
+}


### PR DESCRIPTION
When evaluating variables, values with spaces will only evaluate the first word/character before a space and ignore the rest. This is especially bad because this fails silently in most cases and can lead to confusing scenarios.

This ensures that any value that contains a space must have quotes surrounding it so that it is valid.

This does not consider any value that has a leading or trailing space since that is managed by other checks/fixes.

Further Fixes: https://github.com/dotenv-linter/dotenv-linter/issues/343

#### ✔ Checklist:

- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] This PR has been added to [CHANGELOG.md](https://github.com/dotenv-linter/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [X] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).