### PR TITLE
fix: don't remove quotes for values containing hash-sign

### DIFF
--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -22,7 +22,11 @@ impl Default for QuoteCharacterChecker<'_> {
 impl Check for QuoteCharacterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let val = line.get_value()?;
-        if val.contains("\\n") || val.contains(char::is_whitespace) || val.contains('$') {
+        if val.contains("\\n")
+            || val.contains(char::is_whitespace)
+            || val.contains('$')
+            || val.contains('#')
+        {
             return None;
         }
 
@@ -75,6 +79,19 @@ mod tests {
         check_test(
             &mut QuoteCharacterChecker::default(),
             [("BAR=\"$ABC\"", None), ("FOO='${BAR}BAR'", None)],
+        );
+    }
+
+    #[test]
+    fn with_comments_test() {
+        check_test(
+            &mut QuoteCharacterChecker::default(),
+            [
+                ("FOO=\"with #comment\"", None),
+                ("FOO='with #comment'", None),
+                ("FOO=\"#only-comment\"", None),
+                ("FOO='#only-comment'", None),
+            ],
         );
     }
 


### PR DESCRIPTION
Ensure that values containing would-be comments are not altered by stripping quotes.

Refs: #559

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
