### PR TITLE
Add commit standar for the CONTRIBUTION file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # 🤝 Contributing
 
+For all contributions it is necessary that commits are made following a standard, that is why we use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
 ## How to set up the project
 
 ### 🦀 Install Rust via [rustup](https://rustup.rs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # 🤝 Contributing
 
-For all contributions it is necessary that commits are made following a standard, that is why we use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+For all contributions it is necessary that commits are made following a standard, that is why we use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## How to set up the project
 


### PR DESCRIPTION
Suggestion proposed on #555 

#### ✔ Checklist:

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;

> I'm thinking that maybe adding a hook to control this would be a great addition, let me know if you would like me to do it in this PR or another one