### PR TITLE
ci: replace `actions-rs/toolchain` with `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,10 +11,7 @@ jobs:
     if: ${{ github.event.label.name == 'benchmark' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.1
       - run: cargo check --all-targets
       - run: cargo fmt --all --check
@@ -30,11 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
+      # https://github.com/dtolnay/rust-toolchain/issues/29
+      - run: rustup override set nightly
       - name: Set grcov version
         run: echo "GRCOV_VERSION=$(cargo search --limit 1 grcov | head -n1 | cut -d '"' -f2)" >> $GITHUB_ENV
       - uses: Swatinem/rust-cache@v2.0.1
@@ -59,10 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.1
       - run: cargo install cargo-sort
       - run: cargo-sort --check
@@ -87,10 +78,7 @@ jobs:
       - name: Disable EOL conversion
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.1
       - run: cargo test --all-features --no-fail-fast
 
@@ -216,11 +204,10 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.TOOLCHAIN }}
-          target: ${{ matrix.TARGET }}
-          override: true
+          targets: ${{ matrix.TARGET }}
       - uses: Swatinem/rust-cache@v2.0.1
         with:
           key: ${{ matrix.TARGET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,10 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.TOOLCHAIN }}
-          target: ${{ matrix.TARGET }}
-          override: true
+          targets: ${{ matrix.TARGET }}
       - uses: Swatinem/rust-cache@v2.0.1
         with:
           key: ${{ matrix.TARGET }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/src/common/comment.rs
+++ b/src/common/comment.rs
@@ -5,7 +5,7 @@ const PREFIX: &str = "dotenv-linter";
 const ON: &str = "on";
 const OFF: &str = "off";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Comment {
     disable: bool,
     pub checks: Vec<LintKind>,

--- a/src/common/line_entry.rs
+++ b/src/common/line_entry.rs
@@ -1,6 +1,6 @@
 use super::{comment::Comment, is_escaped};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LineEntry {
     pub number: usize,
     pub raw_string: String,

--- a/src/common/warning.rs
+++ b/src/common/warning.rs
@@ -2,7 +2,7 @@ use super::LintKind;
 use colored::*;
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Warning {
     pub check_name: LintKind,
     pub line_number: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,12 +315,9 @@ fn find_multiline_ranges(lines: &[LineEntry]) -> Vec<(usize, usize)> {
 
 /// Returns the `QuoteType` for a `&str` starting with a quote-char
 fn is_multiline_start(val: &str) -> Option<QuoteType> {
-    for quote_type in [QuoteType::Single, QuoteType::Double] {
-        if quote_type.is_quoted_value(val) {
-            return Some(quote_type);
-        }
-    }
-    None
+    [QuoteType::Single, QuoteType::Double]
+        .into_iter()
+        .find(|quote_type| quote_type.is_quoted_value(val))
 }
 
 /// Prints information about the new version to `STDOUT` if a new version is available


### PR DESCRIPTION
Because `actions-rs` [is unmaintained](https://github.com/actions-rs/toolchain/issues/216).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
