### PR TITLE
refactor(cli): get rid of `list` command

### DIFF
--- a/benches/check.rs
+++ b/benches/check.rs
@@ -11,7 +11,8 @@ pub fn check_benchmark(c: &mut Criterion) {
 
     let current_dir = env::current_dir().expect("get current dir");
     let app = dotenv_linter::cli::command();
-    let matches = app.get_matches_from(vec!["dotenv-linter", path.to_str().expect("path to str")]);
+    let args = app.get_matches_from(vec!["dotenv-linter", path.to_str().expect("path to str")]);
+    let opts = dotenv_linter::cli::options::CheckOptions::new(&args);
 
     fs::copy("benches/fixtures/simple.env", path.join(".env")).expect("copy .env file");
 
@@ -20,7 +21,7 @@ pub fn check_benchmark(c: &mut Criterion) {
         #[cfg(not(windows))]
         let _print_gag = Gag::stdout().expect("disable stdout");
 
-        b.iter(|| dotenv_linter::check(black_box(&matches), black_box(&current_dir)))
+        b.iter(|| dotenv_linter::check(black_box(&opts), black_box(&current_dir)))
     });
 }
 

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -11,7 +11,7 @@ pub fn compare_benchmark(c: &mut Criterion) {
 
     let current_dir = env::current_dir().expect("get current dir");
     let app = dotenv_linter::cli::command();
-    let matches = app.get_matches_from(vec![
+    let args = app.get_matches_from(vec![
         "dotenv-linter",
         "compare",
         path.join(".env").to_str().expect(".env to str"),
@@ -19,6 +19,7 @@ pub fn compare_benchmark(c: &mut Criterion) {
             .to_str()
             .expect(".env.compare to str"),
     ]);
+    let opts = dotenv_linter::cli::options::CompareOptions::new(&args);
 
     fs::copy("benches/fixtures/simple.env", path.join(".env")).expect("copy .env file");
     fs::copy("benches/fixtures/compare.env", path.join(".env.compare"))
@@ -29,7 +30,7 @@ pub fn compare_benchmark(c: &mut Criterion) {
         #[cfg(not(windows))]
         let _print_gag = Gag::stdout().expect("disable stdout");
 
-        b.iter(|| dotenv_linter::compare(black_box(&matches), black_box(&current_dir)))
+        b.iter(|| dotenv_linter::compare(black_box(&opts), black_box(&current_dir)))
     });
 }
 

--- a/benches/fix.rs
+++ b/benches/fix.rs
@@ -40,7 +40,10 @@ pub fn fix_benchmark(c: &mut Criterion) {
         // iter_batched, so we can copy the files beforehand
         b.iter_batched(
             || generate_arg_matches(&app, false),
-            |arguments| dotenv_linter::fix(black_box(&arguments), black_box(&current_dir)),
+            |args| {
+                let opts = dotenv_linter::cli::options::FixOptions::new(&args);
+                dotenv_linter::fix(black_box(&opts), black_box(&current_dir))
+            },
             BatchSize::SmallInput,
         )
     });
@@ -56,7 +59,10 @@ pub fn fix_benchmark_with_backup(c: &mut Criterion) {
         // iter_batched, so we can copy the files beforehand
         b.iter_batched(
             || generate_arg_matches(&app, true),
-            |arguments| dotenv_linter::fix(black_box(&arguments), black_box(&current_dir)),
+            |args| {
+                let opts = dotenv_linter::cli::options::FixOptions::new(&args);
+                dotenv_linter::fix(black_box(&opts), black_box(&current_dir))
+            },
             BatchSize::SmallInput,
         )
     });

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -42,10 +42,6 @@ fn checklist() -> Vec<Box<dyn Check>> {
     ]
 }
 
-pub fn available_check_names() -> Vec<LintKind> {
-    checklist().iter().map(|check| check.name()).collect()
-}
-
 pub fn run(lines: &[LineEntry], skip_checks: &[LintKind]) -> Vec<Warning> {
     let mut checks = checklist();
 
@@ -255,15 +251,6 @@ mod tests {
         let skip_checks: Vec<LintKind> = Vec::new();
 
         assert_eq!(expected, run(&lines, &skip_checks));
-    }
-
-    #[test]
-    fn check_name_list() {
-        let available_check_names = available_check_names();
-        for check in checklist() {
-            let check_name = check.name();
-            assert!(available_check_names.iter().any(|name| name == &check_name));
-        }
     }
 
     #[test]

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -1,0 +1,76 @@
+use crate::common::LintKind;
+use clap::ArgMatches;
+use std::path::PathBuf;
+
+pub struct CheckOptions<'a> {
+    pub input: Vec<&'a PathBuf>,
+    pub skip: Vec<LintKind>,
+    pub exclude: Vec<&'a PathBuf>,
+    pub quiet: bool,
+    pub recursive: bool,
+}
+
+pub struct FixOptions<'a> {
+    pub input: Vec<&'a PathBuf>,
+    pub skip: Vec<LintKind>,
+    pub exclude: Vec<&'a PathBuf>,
+    pub quiet: bool,
+    pub recursive: bool,
+    pub no_backup: bool,
+}
+
+pub struct CompareOptions<'a> {
+    pub input: Vec<&'a PathBuf>,
+    pub quiet: bool,
+}
+
+impl<'a> CheckOptions<'a> {
+    pub fn new(args: &'a ArgMatches) -> Self {
+        let skip = get_many_from_args::<LintKind>(args, "skip")
+            .into_iter()
+            .map(|l| l.to_owned())
+            .collect();
+
+        Self {
+            skip,
+            input: get_many_from_args::<PathBuf>(args, "input"),
+            exclude: get_many_from_args::<PathBuf>(args, "exclude"),
+            quiet: args.get_flag("quiet"),
+            recursive: args.get_flag("recursive"),
+        }
+    }
+}
+
+impl<'a> FixOptions<'a> {
+    pub fn new(args: &'a ArgMatches) -> Self {
+        let skip = get_many_from_args::<LintKind>(args, "skip")
+            .into_iter()
+            .map(|l| l.to_owned())
+            .collect();
+
+        Self {
+            skip,
+            input: get_many_from_args::<PathBuf>(args, "input"),
+            exclude: get_many_from_args::<PathBuf>(args, "exclude"),
+            quiet: args.get_flag("quiet"),
+            recursive: args.get_flag("recursive"),
+            no_backup: args.get_flag("no-backup"),
+        }
+    }
+}
+
+impl<'a> CompareOptions<'a> {
+    pub fn new(args: &'a ArgMatches) -> Self {
+        Self {
+            input: get_many_from_args::<PathBuf>(args, "input"),
+            quiet: args.get_flag("quiet"),
+        }
+    }
+}
+
+fn get_many_from_args<'a, T: Clone + Send + Sync + 'static>(
+    args: &'a ArgMatches,
+    name: &'a str,
+) -> Vec<&'a T> {
+    args.get_many::<T>(name).unwrap_or_default().collect()
+}

--- a/src/common/lint_kind.rs
+++ b/src/common/lint_kind.rs
@@ -1,3 +1,5 @@
+use clap::builder::PossibleValue;
+use clap::ValueEnum;
 use std::{fmt, str::FromStr};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -15,6 +17,44 @@ pub enum LintKind {
     TrailingWhitespace,
     UnorderedKey,
     ValueWithoutQuotes,
+}
+
+impl ValueEnum for LintKind {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            LintKind::DuplicatedKey,
+            LintKind::EndingBlankLine,
+            LintKind::ExtraBlankLine,
+            LintKind::IncorrectDelimiter,
+            LintKind::KeyWithoutValue,
+            LintKind::LeadingCharacter,
+            LintKind::LowercaseKey,
+            LintKind::QuoteCharacter,
+            LintKind::SpaceCharacter,
+            LintKind::SubstitutionKey,
+            LintKind::TrailingWhitespace,
+            LintKind::UnorderedKey,
+            LintKind::ValueWithoutQuotes,
+        ]
+    }
+
+    fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
+        Some(match self {
+            LintKind::DuplicatedKey => PossibleValue::new("DuplicatedKey"),
+            LintKind::EndingBlankLine => PossibleValue::new("EndingBlankLine"),
+            LintKind::ExtraBlankLine => PossibleValue::new("ExtraBlankLine"),
+            LintKind::IncorrectDelimiter => PossibleValue::new("IncorrectDelimiter"),
+            LintKind::KeyWithoutValue => PossibleValue::new("KeyWithoutValue"),
+            LintKind::LeadingCharacter => PossibleValue::new("LeadingCharacter"),
+            LintKind::LowercaseKey => PossibleValue::new("LowercaseKey"),
+            LintKind::QuoteCharacter => PossibleValue::new("QuoteCharacter"),
+            LintKind::SpaceCharacter => PossibleValue::new("SpaceCharacter"),
+            LintKind::SubstitutionKey => PossibleValue::new("SubstitutionKey"),
+            LintKind::TrailingWhitespace => PossibleValue::new("TrailingWhitespace"),
+            LintKind::UnorderedKey => PossibleValue::new("UnorderedKey"),
+            LintKind::ValueWithoutQuotes => PossibleValue::new("ValueWithoutQuotes"),
+        })
+    }
 }
 
 impl FromStr for LintKind {
@@ -52,18 +92,13 @@ mod tests {
 
     #[test]
     fn test_str_to_lint_variant_conversion() {
-        let lint_as_str = "DuplicatedKey";
-        let expected = LintKind::from_str(lint_as_str).unwrap();
-
+        let expected = <LintKind as FromStr>::from_str("DuplicatedKey").unwrap();
         assert_eq!(expected, LintKind::DuplicatedKey);
     }
 
     #[test]
     fn test_invalid_lint_str_variant() {
-        let invalid_lint_str = "FooBarLint";
-        let expected = Err(());
-
-        assert_eq!(expected, LintKind::from_str(invalid_lint_str));
+        assert_eq!(Err(()), <LintKind as FromStr>::from_str("FooBarLint"));
     }
 
     #[test]

--- a/tests/flags/check_updates.rs
+++ b/tests/flags/check_updates.rs
@@ -23,5 +23,6 @@ fn print_new_version_if_nothing_to_check() {
     let test_dir = TestDir::new();
     let expected_output = format!("Nothing to check\n\n{}\n", new_version_output());
 
-    test_dir.test_command_success_with_args(&[""], expected_output);
+    let args: &[&str; 0] = &[];
+    test_dir.test_command_success_with_args(args, expected_output);
 }


### PR DESCRIPTION
It was moved to help:
```
Lightning-fast linter for .env files

Usage: dotenv-linter [OPTIONS] [input]... [COMMAND]

Commands:
  compare  Compares if files have the same keys [aliases: c]
  fix      Automatically fixes warnings [aliases: f]

Arguments:
  [input]...  files or paths

Options:
  -e, --exclude [<FILE_NAME>...]  Excludes files from check
  -s, --skip [<CHECK_NAME>...]    Skips checks [possible values: DuplicatedKey, EndingBlankLine, ExtraBlankLine, IncorrectDelimiter, KeyWithoutValue, LeadingCharacter, LowercaseKey, QuoteCharacter, SpaceCharacter, SubstitutionKey, TrailingWhitespace, UnorderedKey, ValueWithoutQuotes]
  -r, --recursive                 Recursively searches and checks .env files
      --no-color                  Turns off the colored output
  -q, --quiet                     Doesn't display additional information
      --not-check-updates         Doesn't check for updates
  -h, --help                      Print help information
  -V, --version                   Print version information
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
