### PR TITLE
ci: get rid of `set-output`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
       # see: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167#M1027
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Build and publish to aur.archlinux.org
         run: |


### PR DESCRIPTION
Closes #622 


#### ✔ Checklist:

- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
