### PR TITLE
chore: replace `colored` with `owo-colors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,17 +171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,11 +297,11 @@ version = "3.3.0"
 dependencies = [
  "assert_cmd",
  "clap 4.1.8",
- "colored",
  "criterion",
  "dotenv-lookup",
  "dunce",
  "gag",
+ "owo-colors",
  "tempfile",
  "update-informer",
 ]
@@ -505,6 +494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +617,15 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -887,6 +891,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/dotenv-linter/Cargo.toml
+++ b/dotenv-linter/Cargo.toml
@@ -14,8 +14,8 @@ description = "Lightning-fast linter for .env files"
 
 [dependencies]
 clap = { version = "4.1.8", features = ["cargo", "env"] }
-colored = "2.0.0"
 dotenv-lookup = { version = "1.0.0", path = "../dotenv-lookup" }
+owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 
 [dependencies.update-informer]
 version = "0.6.0"

--- a/dotenv-linter/src/cli/mod.rs
+++ b/dotenv-linter/src/cli/mod.rs
@@ -9,9 +9,6 @@ use std::path::PathBuf;
 pub mod options;
 
 pub fn run() -> Result<i32> {
-    #[cfg(windows)]
-    colored::control::set_virtual_terminal(true).ok();
-
     let current_dir = std::env::current_dir()?;
     let args = command().get_matches();
 
@@ -161,7 +158,7 @@ fn not_check_updates_flag() -> Arg {
 
 fn disable_color_output(args: &clap::ArgMatches) {
     if args.get_flag("no-color") {
-        colored::control::set_override(false);
+        owo_colors::set_override(false);
     }
 }
 

--- a/dotenv-linter/src/common/compare.rs
+++ b/dotenv-linter/src/common/compare.rs
@@ -1,4 +1,4 @@
-use colored::*;
+use owo_colors::{OwoColorize, Stream, Style};
 use std::{fmt, path::PathBuf};
 
 // A structure used to compare environment files
@@ -18,10 +18,15 @@ impl fmt::Display for CompareWarning {
         write!(
             f,
             "{} is missing keys: {}",
-            self.path.display().to_string().italic(),
+            self.path
+                .display()
+                .to_string()
+                .if_supports_color(Stream::Stdout, |text| text.italic()),
             self.missing_keys
                 .iter()
-                .map(|k| k.red().bold().to_string())
+                .map(|k| k
+                    .if_supports_color(Stream::Stdout, |text| text.style(Style::new().red().bold()))
+                    .to_string())
                 .collect::<Vec<String>>()
                 .join(", ")
         )

--- a/dotenv-linter/src/common/output/check.rs
+++ b/dotenv-linter/src/common/output/check.rs
@@ -1,6 +1,6 @@
 use crate::common::Warning;
-use colored::*;
 use dotenv_lookup::FileEntry;
+use owo_colors::{OwoColorize, Stream, Style};
 
 pub struct CheckOutput {
     // Quiet program output mode
@@ -40,9 +40,13 @@ impl CheckOutput {
 
     /// Prints warnings without any additional information
     pub fn print_warnings(&self, file: &FileEntry, warnings: &[Warning], file_index: usize) {
-        warnings
-            .iter()
-            .for_each(|w| println!("{}{}", format!("{}:", file).italic(), w));
+        warnings.iter().for_each(|w| {
+            println!(
+                "{}{}",
+                format!("{}:", file).if_supports_color(Stream::Stdout, |text| text.italic()),
+                w
+            )
+        });
 
         if self.is_quiet_mode {
             return;
@@ -68,10 +72,16 @@ impl CheckOutput {
 
             println!(
                 "\n{}",
-                format!("{} {} {}", "Found", total, problems).red().bold()
+                format!("{} {} {}", "Found", total, problems)
+                    .if_supports_color(Stream::Stdout, |text| text
+                        .style(Style::new().red().bold()))
             );
         } else {
-            println!("\n{}", "No problems found".green().bold());
+            println!(
+                "\n{}",
+                "No problems found".if_supports_color(Stream::Stdout, |text| text
+                    .style(Style::new().green().bold()))
+            );
         }
     }
 }

--- a/dotenv-linter/src/common/output/fix.rs
+++ b/dotenv-linter/src/common/output/fix.rs
@@ -1,6 +1,6 @@
 use crate::common::Warning;
-use colored::*;
 use dotenv_lookup::FileEntry;
+use owo_colors::{OwoColorize, Stream, Style};
 use std::path::Path;
 
 /// Prefix for the backup output
@@ -57,9 +57,13 @@ impl FixOutput {
             return;
         }
 
-        warnings
-            .iter()
-            .for_each(|w| println!("{}{}", format!("{}:", file).italic(), w));
+        warnings.iter().for_each(|w| {
+            println!(
+                "{}{}",
+                format!("{}:", file).if_supports_color(Stream::Stdout, |text| text.italic()),
+                w
+            )
+        });
 
         let is_last_file = file_index == self.files_count - 1;
         if !warnings.is_empty() && !is_last_file {
@@ -82,6 +86,10 @@ impl FixOutput {
             return;
         }
 
-        println!("{}", "Could not fix all warnings".red().bold());
+        println!(
+            "{}",
+            "Could not fix all warnings"
+                .if_supports_color(Stream::Stdout, |text| text.style(Style::new().red().bold()))
+        );
     }
 }

--- a/dotenv-linter/src/common/warning.rs
+++ b/dotenv-linter/src/common/warning.rs
@@ -1,5 +1,5 @@
 use super::LintKind;
-use colored::*;
+use owo_colors::{OwoColorize, Stream, Style};
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -25,8 +25,12 @@ impl fmt::Display for Warning {
         write!(
             f,
             "{} {}: {}",
-            format!("{}", self.line_number).italic(),
-            self.check_name.to_string().red().bold(),
+            self.line_number
+                .to_string()
+                .if_supports_color(Stream::Stdout, |text| text.italic()),
+            self.check_name
+                .to_string()
+                .if_supports_color(Stream::Stdout, |text| text.style(Style::new().red().bold())),
             self.message
         )
     }
@@ -43,8 +47,11 @@ mod tests {
         assert_eq!(
             format!(
                 "{} {}: {}",
-                format!("{}", 1).italic(),
-                LintKind::DuplicatedKey.to_string().red().bold(),
+                format!("{}", 1).if_supports_color(Stream::Stdout, |text| text.italic()),
+                LintKind::DuplicatedKey
+                    .to_string()
+                    .if_supports_color(Stream::Stdout, |test| test
+                        .style(Style::new().red().bold())),
                 "The FOO key is duplicated"
             ),
             format!("{}", warning)

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -150,7 +150,7 @@ pub fn compare(opts: &CompareOptions, current_dir: &PathBuf) -> Result<usize> {
 /// Checks for updates and prints information about the new version to `STDOUT`
 #[cfg(feature = "update-informer")]
 pub(crate) fn check_for_updates() {
-    use colored::*;
+    use owo_colors::{OwoColorize, Stream, Style};
     use update_informer::{registry, Check};
 
     let pkg_name = env!("CARGO_PKG_NAME");
@@ -167,18 +167,24 @@ pub(crate) fn check_for_updates() {
     if let Ok(Some(version)) = informer.check_version() {
         let msg = format!(
             "A new release of {pkg_name} is available: v{current_version} -> {new_version}",
-            pkg_name = pkg_name.italic().cyan(),
+            pkg_name = pkg_name.if_supports_color(Stream::Stdout, |text| text
+                .style(Style::new().cyan().italic())),
             current_version = current_version,
-            new_version = version.to_string().green()
+            new_version = version
+                .to_string()
+                .if_supports_color(Stream::Stdout, |text| text.green())
         );
 
         let release_url = format!(
             "https://github.com/{pkg_name}/{pkg_name}/releases/tag/{version}",
             pkg_name = pkg_name,
             version = version
-        )
-        .yellow();
+        );
 
-        println!("\n{msg}\n{url}", msg = msg, url = release_url);
+        println!(
+            "\n{msg}\n{url}",
+            msg = msg,
+            url = release_url.if_supports_color(Stream::Stdout, |text| text.yellow())
+        );
     }
 }


### PR DESCRIPTION
I saw issue #643 open and figured it would be good for a second attempt at contributing to an open-source project. Text styling now depends on `owo-colors`, though I couldn't figure out if I should remove `colored` from the project completely because of the line below in `dotenv-linter/src/cli/mod.rs`:
```rust
#[cfg(windows)]
colored::control::set_virtual_terminal(true).ok();
```
How should this be dealt with?

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
