### PR TITLE
feat: add "No difference found" message on successful compare

### DIFF
--- a/dotenv-linter/src/common/output/compare.rs
+++ b/dotenv-linter/src/common/output/compare.rs
@@ -29,4 +29,11 @@ impl CompareOutput {
             println!("Nothing to compare");
         }
     }
+
+    /// Prints "No difference found" when the two compared files have no difference
+    pub fn print_no_difference_found(&self) {
+        if !self.is_quiet_mode {
+            println!("No difference found");
+        }
+    }
 }

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -140,13 +140,13 @@ pub fn compare(opts: &CompareOptions, current_dir: &PathBuf) -> Result<usize> {
             };
 
             warnings.push(warning)
-        } 
+        }
     }
 
     // Create success message if no warnings found.
     if warnings.len() == 0 {
         output.print_no_difference_found();
-        return Ok(0)
+        return Ok(0);
     }
 
     output.print_warnings(&warnings);

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -140,7 +140,13 @@ pub fn compare(opts: &CompareOptions, current_dir: &PathBuf) -> Result<usize> {
             };
 
             warnings.push(warning)
-        }
+        } 
+    }
+
+    // Create success message if no warnings found.
+    if warnings.len() == 0 {
+        output.print_no_difference_found();
+        return Ok(0)
     }
 
     output.print_warnings(&warnings);

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -144,7 +144,7 @@ pub fn compare(opts: &CompareOptions, current_dir: &PathBuf) -> Result<usize> {
     }
 
     // Create success message if no warnings found.
-    if warnings.len() == 0 {
+    if warnings.is_empty() {
         output.print_no_difference_found();
         return Ok(0);
     }

--- a/dotenv-linter/tests/compare/compare.rs
+++ b/dotenv-linter/tests/compare/compare.rs
@@ -5,7 +5,7 @@ fn files_with_same_environment_variables() {
     let test_dir = TestDir::new();
     let testfile_one = test_dir.create_testfile(".env1", "FOO=abc\nBAR=def");
     let testfile_two = test_dir.create_testfile(".env2", "FOO=abc\nBAR=def");
-    let expected_output = "Comparing .env1\nComparing .env2\n";
+    let expected_output = "Comparing .env1\nComparing .env2\nNo difference found\n";
 
     test_dir.test_command_success_with_args(
         &["compare", testfile_one.as_str(), testfile_two.as_str()],


### PR DESCRIPTION
This addresses Issue: https://github.com/dotenv-linter/dotenv-linter/issues/647 

When two files are compared and no difference is found, the program prints 
```
Comparing file1...
Comparing file2...
```
This then ends and goes back to the command line. My PR will change the functionality to show
```
Comparing file1...
Comparing file2...
No difference found
```
This will add some clarity on the compare command that no difference was found and no error caused the program to finish prematurely.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
