### PR TITLE
feat: add `--dry-run` option to fix subcommand

### DIFF
--- a/dotenv-linter/src/cli.rs
+++ b/dotenv-linter/src/cli.rs
@@ -93,6 +93,12 @@ fn fix_command() -> Command {
                 .help("Prevents backing up .env files")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("dry-run")
+                .long("dry-run")
+                .help("Output the fixed file to stdout without writing it to disk")
+                .action(ArgAction::SetTrue),
+        )
         .override_usage("dotenv-linter fix [OPTIONS] <input>...")
         .about("Automatically fixes warnings")
 }

--- a/dotenv-linter/src/cli/options.rs
+++ b/dotenv-linter/src/cli/options.rs
@@ -21,6 +21,7 @@ pub struct FixOptions<'a> {
     pub quiet: bool,
     pub recursive: bool,
     pub no_backup: bool,
+    pub dry_run: bool,
 }
 
 pub struct CompareOptions<'a> {
@@ -70,6 +71,7 @@ impl<'a> FixOptions<'a> {
             quiet: args.get_flag("quiet"),
             recursive: args.get_flag("recursive"),
             no_backup: args.get_flag("no-backup"),
+            dry_run: args.get_flag("dry-run")
         }
     }
 }

--- a/dotenv-linter/src/common/output/fix.rs
+++ b/dotenv-linter/src/common/output/fix.rs
@@ -86,12 +86,15 @@ impl FixOutput {
     }
 
     /// Prints dry run message
-    pub fn print_dry_run(&self, lines: Vec<LineEntry>) {
+    pub fn print_dry_run(&self, lines: &[LineEntry]) {
         if self.is_quiet_mode {
             return;
         }
 
-        println!("{}\n", "Dry run - not changing any files on disk.".yellow().bold());
+        println!(
+            "{}\n",
+            "Dry run - not changing any files on disk.".yellow().bold()
+        );
 
         for line in lines[..lines.len()].iter() {
             println!("{}", line.raw_string);

--- a/dotenv-linter/src/common/output/fix.rs
+++ b/dotenv-linter/src/common/output/fix.rs
@@ -96,7 +96,7 @@ impl FixOutput {
             "Dry run - not changing any files on disk.".yellow().bold()
         );
 
-        for line in lines[..lines.len()].iter() {
+        for line in lines {
             println!("{}", line.raw_string);
         }
     }

--- a/dotenv-linter/src/common/output/fix.rs
+++ b/dotenv-linter/src/common/output/fix.rs
@@ -1,6 +1,6 @@
 use crate::common::Warning;
 use colored::*;
-use dotenv_lookup::FileEntry;
+use dotenv_lookup::{FileEntry, LineEntry};
 use std::path::Path;
 
 /// Prefix for the backup output
@@ -83,5 +83,18 @@ impl FixOutput {
         }
 
         println!("{}", "Could not fix all warnings".red().bold());
+    }
+
+    /// Prints dry run message
+    pub fn print_dry_run(&self, lines: Vec<LineEntry>) {
+        if self.is_quiet_mode {
+            return;
+        }
+
+        println!("{}\n", "Dry run - not changing any files on disk.".yellow().bold());
+
+        for line in lines[..lines.len()].iter() {
+            println!("{}", line.raw_string);
+        }
     }
 }

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -71,7 +71,10 @@ pub fn fix(opts: &FixOptions, current_dir: &PathBuf) -> Result<()> {
         if fixes_done != result.len() {
             output.print_not_all_warnings_fixed();
         }
-        if fixes_done > 0 {
+
+        if opts.dry_run {
+            output.print_dry_run(lines);
+        } else if fixes_done > 0 {
             let should_backup = !opts.no_backup;
             // create backup copy unless user specifies not to
             if should_backup {

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -73,7 +73,7 @@ pub fn fix(opts: &FixOptions, current_dir: &PathBuf) -> Result<()> {
         }
 
         if opts.dry_run {
-            output.print_dry_run(lines);
+            output.print_dry_run(&lines);
         } else if fixes_done > 0 {
             let should_backup = !opts.no_backup;
             // create backup copy unless user specifies not to

--- a/dotenv-linter/tests/output/fix.rs
+++ b/dotenv-linter/tests/output/fix.rs
@@ -20,6 +20,40 @@ All warnings are fixed. Total: 1
 }
 
 #[test]
+fn warnings_dry_run() {
+    let test_dir = TestDir::new();
+    let test_str = "abc=DEF\nABC=DEF\nA=DEF\nABC=DEF\n";
+    test_dir.create_testfile(".env", test_str);
+
+    let args: &[&str] = &["--dry-run"];
+    let expected_output = r#"Fixing .env
+Dry run - not changing any files on disk.
+
+A=DEF
+ABC=DEF
+# ABC=DEF
+# ABC=DEF
+
+
+.env:1 LowercaseKey: The abc key should be in uppercase
+.env:2 UnorderedKey: The ABC key should go before the abc key
+.env:3 UnorderedKey: The A key should go before the ABC key
+.env:4 DuplicatedKey: The ABC key is duplicated
+.env:4 UnorderedKey: The ABC key should go before the ABC key
+
+All warnings are fixed. Total: 5
+"#;
+
+    test_dir.test_command_fix_success_with_args(expected_output, args);
+    assert_eq!(
+        test_str,
+        fs::read_to_string(test_dir.as_str().to_owned() + "/.env").unwrap(),
+        ".env file should be unmodified"
+    );
+    test_dir.close();
+}
+
+#[test]
 fn warnings_multiple_files() {
     let test_dir = TestDir::new();
     test_dir.create_testfile(".env", "abc=DEF\n");


### PR DESCRIPTION
#### ✔ Checklist:

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features). https://github.com/dotenv-linter/dotenv-linter.github.io/pull/61