### PR TITLE
feat(fixes): support preserver-comments-position arg

### DIFF
--- a/dotenv-linter/src/cli.rs
+++ b/dotenv-linter/src/cli.rs
@@ -99,6 +99,11 @@ fn fix_command() -> Command {
                 .help("Output the fixed file to stdout without writing it to disk")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("preserve-comments-position")
+                .long("preserve-comments-position")
+                .action(ArgAction::SetTrue),
+        )
         .override_usage("dotenv-linter fix [OPTIONS] <input>...")
         .about("Automatically fixes warnings")
 }

--- a/dotenv-linter/src/cli/options.rs
+++ b/dotenv-linter/src/cli/options.rs
@@ -22,6 +22,7 @@ pub struct FixOptions<'a> {
     pub recursive: bool,
     pub no_backup: bool,
     pub dry_run: bool,
+    pub preserve_comments_position: bool,
 }
 
 pub struct CompareOptions<'a> {
@@ -72,6 +73,7 @@ impl<'a> FixOptions<'a> {
             recursive: args.get_flag("recursive"),
             no_backup: args.get_flag("no-backup"),
             dry_run: args.get_flag("dry-run"),
+            preserve_comments_position: args.get_flag("preserve-comments-position"),
         }
     }
 }

--- a/dotenv-linter/src/lib.rs
+++ b/dotenv-linter/src/lib.rs
@@ -67,7 +67,12 @@ pub fn fix(opts: &FixOptions, current_dir: &PathBuf) -> Result<()> {
         if result.is_empty() {
             continue;
         }
-        let fixes_done = fixes::run(&result, &mut lines, &opts.skip);
+        let fixes_done = fixes::run(
+            &result,
+            &mut lines,
+            &opts.skip,
+            opts.preserve_comments_position,
+        );
         if fixes_done != result.len() {
             output.print_not_all_warnings_fixed();
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

## Why

close #749 

## What

Support `preserve-comments-position` for the fix subcommand.

## How

1. Add `preserve-comments-position` in the command arguments parser, and the `FixOptions` struct.
2. If `preserve-comments-position` is `true`, then stop grouping the comment with the other line when the `sort_part` method is invoked.

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
