### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     commit-message:
       prefix: "chore:"
     open-pull-requests-limit: 10
+    groups:
+      cargo-dependencies:
+        # group minor and patch updates for dependencies
+        # major updates will open their own PR
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +20,8 @@ updates:
     commit-message:
       prefix: "chore:"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        # group minor and patch updates for dependencies
+        # major updates will open their own PR
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
major updates won't be grouped with others

Fixes #800 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
