### PR TITLE
Added `dotenv-linter` hooks to `.pre-commit-hooks.yaml` for checking and fixing `.env` file style (Rust)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,17 @@
     entry: /dotenv-linter
     types: [text]
     files: '\.env*'
+-   id: dotenv-linter-check
+    name: dotenv-linter-check
+    description: "Checks the style of Dotenv files."
+    language: rust
+    entry: dotenv-linter check
+    types: [text]
+    files: '\.env*'
+-   id: dotenv-linter-fix
+    name: dotenv-linter-fix
+    description: "Fix the style of Dotenv files."
+    language: rust
+    entry: dotenv-linter fix --no-backup
+    types: [text]
+    files: '\.env*'


### PR DESCRIPTION
This pull request updates the repository’s `.pre-commit-hooks.yaml` to expose `dotenv-linter` hooks for consumers.

Pre-commit hook additions:

* **`dotenv-linter-check`**: checks `.env` file style to enforce consistency before commits.
* **`dotenv-linter-fix`**: automatically fixes `.env` file style issues, configured to avoid creating backup files.
