### PR TITLE
added --stdin support for each check command. added a --stdin flag to…

### DIFF
--- a/dotenv-cli/src/cli.rs
+++ b/dotenv-cli/src/cli.rs
@@ -47,9 +47,13 @@ enum Command {
         /// .env files or directories to check (one or more required)
         #[arg(
             num_args(1..),
-            required = true,
+            required_unless_present = "stdin",
         )]
         files: Vec<PathBuf>,
+
+        /// Read .env content from stdin instead of files
+        #[arg(long)]
+        stdin: bool,
 
         #[command(flatten)]
         common: CommonArgs,
@@ -129,6 +133,7 @@ pub fn run() -> Result<i32> {
     match cli.command {
         Command::Check {
             files,
+            stdin,
             common,
             schema,
             #[cfg(feature = "update-informer")]
@@ -145,17 +150,30 @@ pub fn run() -> Result<i32> {
                 };
             }
 
-            let total_warnings = crate::check(
-                &CheckOptions {
-                    files: files.iter().collect(),
-                    ignore_checks: common.ignore_checks,
-                    exclude: common.exclude.iter().collect(),
-                    recursive: common.recursive,
-                    quiet: cli.quiet,
-                    schema: dotenv_schema,
-                },
-                &current_dir,
-            )?;
+            let total_warnings = if stdin {
+                crate::check_stdin(
+                    &CheckOptions {
+                        files: vec![],
+                        ignore_checks: common.ignore_checks,
+                        exclude: vec![],
+                        recursive: false,
+                        quiet: cli.quiet,
+                        schema: dotenv_schema,
+                    },
+                )?
+            } else {
+                crate::check(
+                    &CheckOptions {
+                        files: files.iter().collect(),
+                        ignore_checks: common.ignore_checks,
+                        exclude: common.exclude.iter().collect(),
+                        recursive: common.recursive,
+                        quiet: cli.quiet,
+                        schema: dotenv_schema,
+                    },
+                    &current_dir,
+                )?
+            };
 
             #[cfg(feature = "update-informer")]
             if !not_check_updates && !cli.quiet {

--- a/dotenv-cli/src/lib.rs
+++ b/dotenv-cli/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, io::Read, path::PathBuf};
 
 use dotenv_analyzer::LintKind;
 use dotenv_schema::DotEnvSchema;
@@ -56,6 +56,29 @@ pub fn check(opts: &CheckOptions, current_dir: &PathBuf) -> Result<usize> {
 
     output.print_total(warnings_count);
     Ok(warnings_count)
+}
+
+pub fn check_stdin(opts: &CheckOptions) -> Result<usize> {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+
+    let (fe, lines) = dotenv_finder::FileEntry::from_content("stdin".to_string(), &input);
+
+    let output = CheckOutput::new(opts.quiet);
+
+    if lines.is_empty() {
+        output.print_nothing_to_check();
+        return Ok(0);
+    }
+
+    let output = output.files_count(1);
+    output.print_processing_info(&fe);
+
+    let warnings = dotenv_analyzer::check(&lines, &opts.ignore_checks, opts.schema.as_ref());
+    output.print_warnings(&fe, &warnings, 0);
+    output.print_total(warnings.len());
+
+    Ok(warnings.len())
 }
 
 pub struct FixOptions<'a> {

--- a/dotenv-cli/tests/flags/mod.rs
+++ b/dotenv-cli/tests/flags/mod.rs
@@ -1,6 +1,7 @@
 mod backup;
 mod quiet;
 mod recursive;
+mod stdin;
 mod version;
 
 #[cfg(feature = "stub_check_version")]

--- a/dotenv-cli/tests/flags/stdin.rs
+++ b/dotenv-cli/tests/flags/stdin.rs
@@ -1,0 +1,66 @@
+use crate::common::*;
+
+#[test]
+fn stdin_with_valid_content() {
+    let testdir = TestDir::new();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("dotenv-linter").expect("binary");
+    cmd.current_dir(testdir.as_str())
+        .args(with_default_args(&["check", "--stdin"]))
+        .write_stdin("FOO=bar\nBAR=baz\n")
+        .assert()
+        .success();
+}
+
+#[test]
+fn stdin_with_invalid_content() {
+    let testdir = TestDir::new();
+
+    let expected_output = check_output(&[(
+        "stdin",
+        &["stdin:1 SpaceCharacter: The line has spaces around equal sign"],
+    )]);
+
+    let mut cmd = assert_cmd::Command::cargo_bin("dotenv-linter").expect("binary");
+    cmd.current_dir(testdir.as_str())
+        .args(with_default_args(&["check", "--stdin"]))
+        .write_stdin("FOO =bar\n")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(expected_output);
+}
+
+#[test]
+fn stdin_with_empty_content() {
+    let testdir = TestDir::new();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("dotenv-linter").expect("binary");
+    cmd.current_dir(testdir.as_str())
+        .args(with_default_args(&["check", "--stdin"]))
+        .write_stdin("")
+        .assert()
+        .success();
+}
+
+#[test]
+fn stdin_with_multiple_warnings() {
+    let testdir = TestDir::new();
+
+    let expected_output = check_output(&[(
+        "stdin",
+        &[
+            "stdin:1 LowercaseKey: The foo key should be in uppercase",
+            "stdin:2 SpaceCharacter: The line has spaces around equal sign",
+        ],
+    )]);
+
+    let mut cmd = assert_cmd::Command::cargo_bin("dotenv-linter").expect("binary");
+    cmd.current_dir(testdir.as_str())
+        .args(with_default_args(&["check", "--stdin"]))
+        .write_stdin("foo=bar\nBAR =baz\n")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(expected_output);
+}

--- a/dotenv-finder/src/file.rs
+++ b/dotenv-finder/src/file.rs
@@ -75,6 +75,26 @@ impl FileEntry {
             lines,
         ))
     }
+
+    // Creates a FileEntry and line entries from raw string content 
+    pub fn from_content(name: String, content: &str) -> (Self, Vec<LineEntry>) {
+        let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
+
+        if content.ends_with(LF) {
+            lines.push(LF.to_string());
+        }
+
+        let lines = get_line_entries(lines);
+
+        (
+            FileEntry {
+                path: PathBuf::from(&name),
+                file_name: name,
+                total_lines: lines.len(),
+            },
+            lines,
+        )
+    }
 }
 
 /// Checks a file name with the `.env` pattern


### PR DESCRIPTION
… the check subcommand so the linter can receive .env file content via standard input
