### PR TITLE
feat: Modified dotenv-schema to accept Python Booleans

### DIFF
--- a/dotenv-schema/src/lib.rs
+++ b/dotenv-schema/src/lib.rs
@@ -66,7 +66,7 @@ impl SchemaEntry {
             SchemaValueType::Boolean => {
                 if !matches!(
                     value,
-                    "true" | "false" | "TRUE" | "FALSE" | "yes" | "no" | "YES" | "NO" | "1" | "0"
+                    "true" | "false" | "True" | "False" | "TRUE" | "FALSE" | "yes" | "no" | "YES" | "NO" | "1" | "0"
                 ) {
                     return ValidateResult::Invalid(SchemaValueType::Boolean);
                 }


### PR DESCRIPTION
Python Booleans start with a capital letter, this fix adds support for those booleans too.

#### ✔ Checklist:
- [ x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
