### PR TITLE
chore(docker): add OCI image source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; \
   && cargo install --target "${TARGET}" --path dotenv-cli
 
 FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/dotenv-linter/dotenv-linter"
+LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /root/.cargo/bin/dotenv-linter /
 ENTRYPOINT ["/dotenv-linter"]


### PR DESCRIPTION
## Summary

Add standard OCI image labels to the final stage of `Dockerfile` so downstream
tooling (Renovate, Dependabot, Docker Hub image page, GHCR "Connect repository")
can auto-resolve this repository as the image source.

## Why

When consumers update `dotenvlinter/dotenv-linter` via Renovate or Dependabot,
the generated PR body currently has no repository link and no release notes
section — these tools read `org.opencontainers.image.source` from the image
metadata to discover the source repo.

Adding a single `LABEL` line fixes this for every downstream consumer without
any configuration on their side.

## Changes

- Add `LABEL org.opencontainers.image.source` (points to this repo)
- Add `LABEL org.opencontainers.image.licenses="MIT"` (matches the project LICENSE)

## References

- [OCI image-spec — pre-defined annotation keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)
- Same labels are used by projects like renovatebot/renovate and fluent/fluent-bit.

## Verification

- `docker buildx build --platform linux/arm64 -f Dockerfile -t dotenv-linter-test .` succeeds locally.
- `docker image inspect <tag> --format '{{json .Config.Labels}}'` shows the new labels:
  ```json
  {
    "org.opencontainers.image.licenses": "MIT",
    "org.opencontainers.image.source": "https://github.com/dotenv-linter/dotenv-linter"
  }
  ```
- `docker run --rm <tag> --version` → `dotenv-linter 4.0.0`

#### ✔ Checklist:

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format

---

Thanks for maintaining dotenv-linter — happy to adjust anything during review!
