### PR TITLE
fix: keep comment-delimited groups intact in unordered key fixer

### DIFF
--- a/dotenv-analyzer/src/fix/unordered_key.rs
+++ b/dotenv-analyzer/src/fix/unordered_key.rs
@@ -101,9 +101,26 @@ impl Fix for UnorderedKeyFixer {
 
 impl UnorderedKeyFixer {
     fn sort_part(part: &mut [LineEntry]) {
+        let mut sorted_lines = Vec::with_capacity(part.len());
+        let mut start_index = 0;
+
+        for (index, line) in part.iter().enumerate() {
+            if Self::is_group_comment(line) {
+                sorted_lines.extend(Self::sort_slices(&part[start_index..index]));
+                sorted_lines.push(line.clone());
+                start_index = index + 1;
+            }
+        }
+
+        sorted_lines.extend(Self::sort_slices(&part[start_index..]));
+
+        part.clone_from_slice(sorted_lines.as_slice());
+    }
+
+    fn sort_slices(part: &[LineEntry]) -> Vec<LineEntry> {
         // Each slice includes a significant line (with key) and previous comments (if present)
         let mut slices = Vec::with_capacity(part.len());
-        part.iter().enumerate().fold(0, |acc, (i, line)| {
+        let trailing_comments_start = part.iter().enumerate().fold(0, |acc, (i, line)| {
             if !line.is_comment() {
                 slices.push(&part[acc..=i]);
                 i + 1
@@ -114,9 +131,36 @@ impl UnorderedKeyFixer {
 
         slices.sort_by_cached_key(|slice| slice.last()?.get_key());
 
-        let sorted_lines: Vec<_> = slices.into_iter().flat_map(|s| s.iter().cloned()).collect();
+        let mut sorted_lines: Vec<_> = slices.into_iter().flat_map(|s| s.iter().cloned()).collect();
+        sorted_lines.extend(part[trailing_comments_start..].iter().cloned());
+        sorted_lines
+    }
 
-        part.clone_from_slice(sorted_lines.as_slice());
+    fn is_group_comment(line: &LineEntry) -> bool {
+        let Some(comment) = line.get_comment() else {
+            return false;
+        };
+
+        let trimmed = comment.trim();
+        let Some(stripped) = trimmed.strip_prefix('#') else {
+            return false;
+        };
+
+        let stripped = stripped.trim_start_matches('#').trim_start();
+        let Some(direction) = stripped.chars().next() else {
+            return false;
+        };
+
+        if direction != '>' && direction != '<' {
+            return false;
+        }
+
+        let name = stripped[direction.len_utf8()..]
+            .trim()
+            .trim_end_matches('#')
+            .trim();
+
+        !name.is_empty()
     }
 }
 
@@ -812,6 +856,43 @@ mod tests {
                 "\n",
                 "# end comment",
                 "\n",
+            ],
+        );
+    }
+
+    #[test]
+    fn comment_group_markers_stay_in_place_test() {
+        let mut lines = get_lines(vec![
+            "ENV2=bbb",
+            "ENV1=aaa",
+            "",
+            "###> group1 ###",
+            "ENV4=ddd",
+            "ENV5=eee",
+            "ENV3=ccc",
+            "###< group1 ###",
+            "",
+            "ENV7=ggg",
+            "ENV6=fff",
+        ]);
+        let warning_lines = [1, 6, 10];
+
+        assert_eq!(Some(3), run_fixer(&warning_lines, &mut lines));
+
+        assert_lines(
+            &lines,
+            vec![
+                "ENV1=aaa",
+                "ENV2=bbb",
+                "",
+                "###> group1 ###",
+                "ENV3=ccc",
+                "ENV4=ddd",
+                "ENV5=eee",
+                "###< group1 ###",
+                "",
+                "ENV6=fff",
+                "ENV7=ggg",
             ],
         );
     }

--- a/dotenv-analyzer/src/lib.rs
+++ b/dotenv-analyzer/src/lib.rs
@@ -58,12 +58,10 @@ pub(crate) mod tests {
         U: AsRef<[(&'test str, Option<&'test str>)]>,
     {
         let asserts = asserts.as_ref();
-        let mut line_number = 1;
         let total = asserts.len();
 
-        for (input, expected) in asserts {
+        for (line_number, (input, expected)) in (1..).zip(asserts.iter()) {
             let line = line_entry(line_number, total, input);
-            line_number += 1;
 
             let result = checker.run(&line);
             let expected = expected.map(|e| Warning::new(line.number, checker.name(), e));

--- a/dotenv-cli/src/cli.rs
+++ b/dotenv-cli/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand, command};
+use clap::{Args, Parser, Subcommand};
 use dotenv_analyzer::LintKind;
 use dotenv_schema::DotEnvSchema;
 

--- a/dotenv-cli/tests/fixes/unordered_key.rs
+++ b/dotenv-cli/tests/fixes/unordered_key.rs
@@ -26,3 +26,30 @@ fn unordered_key() {
 
     testdir.close();
 }
+
+#[test]
+fn unordered_key_with_comment_group_markers() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(
+        ".env",
+        "ENV2=bbb\nENV1=aaa\n\n###> group1 ###\nENV4=ddd\nENV5=eee\nENV3=ccc\n###< group1 ###\n\
+         \nENV7=ggg\nENV6=fff\n",
+    );
+    let expected_output = fix_output(&[(
+        ".env",
+        &[
+            ".env:2 UnorderedKey: The ENV1 key should go before the ENV2 key",
+            ".env:7 UnorderedKey: The ENV3 key should go before the ENV4 key",
+            ".env:11 UnorderedKey: The ENV6 key should go before the ENV7 key",
+        ],
+    )]);
+    testdir.test_command_fix_success(expected_output);
+
+    assert_eq!(
+        testfile.contents().as_str(),
+        "ENV1=aaa\nENV2=bbb\n\n###> group1 ###\nENV3=ccc\nENV4=ddd\nENV5=eee\n###< group1 ###\n\
+         \nENV6=fff\nENV7=ggg\n",
+    );
+
+    testdir.close();
+}


### PR DESCRIPTION
Fixes `UnorderedKey` auto-fix for comment-delimited env groups. ( #749 )

Previously, markers like `###> group1 ###` could move with the next key during sorting, which allowed keys to escape the intended group. This change keeps those marker comments fixed and sorts keys only within the delimited section.

Added regression tests for both the fixer and the CLI behavior.

#### ✔ Checklist:

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).
