### PR TITLE
feat(cli): add --stdin and --stdin-filename flags for check/fix

### DIFF
--- a/dotenv-cli/benches/check.rs
+++ b/dotenv-cli/benches/check.rs
@@ -17,6 +17,7 @@ pub fn check_benchmark(c: &mut Criterion) {
         quiet: false,
         recursive: false,
         schema: None,
+        stdin: None,
     };
 
     fs::copy("benches/fixtures/simple.env", path.join(".env")).expect("copy .env file");

--- a/dotenv-cli/benches/fix.rs
+++ b/dotenv-cli/benches/fix.rs
@@ -32,6 +32,7 @@ pub fn fix_benchmark(c: &mut Criterion) {
                     recursive: false,
                     no_backup: true,
                     dry_run: false,
+                    stdin: None,
                 };
                 dotenv_linter::fix(black_box(&opts), black_box(&current_dir))
             },
@@ -67,6 +68,7 @@ pub fn fix_benchmark_with_backup(c: &mut Criterion) {
                     recursive: false,
                     no_backup: false,
                     dry_run: false,
+                    stdin: None,
                 };
                 dotenv_linter::fix(black_box(&opts), black_box(&current_dir))
             },

--- a/dotenv-cli/src/cli.rs
+++ b/dotenv-cli/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand, command};
+use clap::{Args, Parser, Subcommand};
 use dotenv_analyzer::LintKind;
 use dotenv_schema::DotEnvSchema;
 
@@ -44,12 +44,21 @@ struct Cli {
 enum Command {
     /// Check .env files for errors such as duplicate keys or invalid syntax
     Check {
-        /// .env files or directories to check (one or more required)
+        /// .env files or directories to check (omit when using --stdin)
         #[arg(
             num_args(1..),
-            required = true,
+            required_unless_present = "stdin",
+            conflicts_with = "stdin",
         )]
         files: Vec<PathBuf>,
+
+        /// Read .env content from STDIN instead of from files
+        #[arg(long)]
+        stdin: bool,
+
+        /// Display name to use for STDIN content in output (used with --stdin)
+        #[arg(long, requires = "stdin", value_name = "NAME", default_value = ".env")]
+        stdin_filename: String,
 
         #[command(flatten)]
         common: CommonArgs,
@@ -65,12 +74,21 @@ enum Command {
     },
     /// Automatically fix issues in .env files
     Fix {
-        /// .env files or directories to fix (one or more required)
+        /// .env files or directories to fix (omit when using --stdin)
         #[arg(
             num_args(1..),
-            required = true,
+            required_unless_present = "stdin",
+            conflicts_with = "stdin",
         )]
         files: Vec<PathBuf>,
+
+        /// Read .env content from STDIN instead of from files (implies --dry-run)
+        #[arg(long)]
+        stdin: bool,
+
+        /// Display name to use for STDIN content in output (used with --stdin)
+        #[arg(long, requires = "stdin", value_name = "NAME", default_value = ".env")]
+        stdin_filename: String,
 
         #[command(flatten)]
         common: CommonArgs,
@@ -129,6 +147,8 @@ pub fn run() -> Result<i32> {
     match cli.command {
         Command::Check {
             files,
+            stdin,
+            stdin_filename,
             common,
             schema,
             #[cfg(feature = "update-informer")]
@@ -145,6 +165,12 @@ pub fn run() -> Result<i32> {
                 };
             }
 
+            let stdin_source = if stdin {
+                Some(read_stdin_to_string()?)
+            } else {
+                None
+            };
+
             let total_warnings = crate::check(
                 &CheckOptions {
                     files: files.iter().collect(),
@@ -153,6 +179,7 @@ pub fn run() -> Result<i32> {
                     recursive: common.recursive,
                     quiet: cli.quiet,
                     schema: dotenv_schema,
+                    stdin: stdin_source.map(|content| (content, stdin_filename)),
                 },
                 &current_dir,
             )?;
@@ -168,10 +195,22 @@ pub fn run() -> Result<i32> {
         }
         Command::Fix {
             files,
+            stdin,
+            stdin_filename,
             common,
             no_backup,
             dry_run,
         } => {
+            let stdin_source = if stdin {
+                Some(read_stdin_to_string()?)
+            } else {
+                None
+            };
+
+            // Fixing STDIN content can't be written back to a file, so it
+            // always behaves as a dry run.
+            let dry_run = dry_run || stdin_source.is_some();
+
             crate::fix(
                 &FixOptions {
                     files: files.iter().collect(),
@@ -182,6 +221,7 @@ pub fn run() -> Result<i32> {
 
                     no_backup,
                     dry_run,
+                    stdin: stdin_source.map(|content| (content, stdin_filename)),
                 },
                 &current_dir,
             )?;
@@ -204,6 +244,15 @@ pub fn run() -> Result<i32> {
     }
 
     Ok(1)
+}
+
+/// Reads the whole content of STDIN into a `String`.
+fn read_stdin_to_string() -> Result<String> {
+    use std::io::Read;
+
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf)?;
+    Ok(buf)
 }
 
 #[cfg(test)]

--- a/dotenv-cli/src/lib.rs
+++ b/dotenv-cli/src/lib.rs
@@ -23,9 +23,25 @@ pub struct CheckOptions<'a> {
     pub quiet: bool,
     pub recursive: bool,
     pub schema: Option<DotEnvSchema>,
+    /// When set, check this (content, display_name) pair read from STDIN
+    /// instead of searching `files` on disk.
+    pub stdin: Option<(String, String)>,
 }
 
 pub fn check(opts: &CheckOptions, current_dir: &PathBuf) -> Result<usize> {
+    if let Some((content, display_name)) = &opts.stdin {
+        let (fe, lines) = dotenv_finder::FileEntry::from_stdin(content, display_name.clone());
+        let output = CheckOutput::new(opts.quiet).files_count(1);
+
+        output.print_processing_info(&fe);
+        let warnings = dotenv_analyzer::check(&lines, &opts.ignore_checks, opts.schema.as_ref());
+        output.print_warnings(&fe, &warnings, 0);
+
+        let warnings_count = warnings.len();
+        output.print_total(warnings_count);
+        return Ok(warnings_count);
+    }
+
     let files = dotenv_finder::FinderBuilder::new(current_dir)
         .with_paths(&opts.files)
         .exclude(&opts.exclude)
@@ -66,9 +82,38 @@ pub struct FixOptions<'a> {
     pub recursive: bool,
     pub no_backup: bool,
     pub dry_run: bool,
+    /// When set, fix this (content, display_name) pair read from STDIN
+    /// instead of searching `files` on disk. Always behaves as a dry run,
+    /// since there is no source file to write the result back to.
+    pub stdin: Option<(String, String)>,
 }
 
 pub fn fix(opts: &FixOptions, current_dir: &PathBuf) -> Result<()> {
+    if let Some((content, display_name)) = &opts.stdin {
+        let (fe, mut lines) = dotenv_finder::FileEntry::from_stdin(content, display_name.clone());
+        let output = FixOutput::new(opts.quiet).files_count(1);
+
+        output.print_processing_info(&fe);
+
+        let warnings = dotenv_analyzer::check(&lines, &opts.ignore_checks, None);
+        if warnings.is_empty() {
+            output.print_total(0);
+            return Ok(());
+        }
+
+        let fixes_done = dotenv_analyzer::fix(&warnings, &mut lines, &opts.ignore_checks);
+        if fixes_done != warnings.len() {
+            output.print_not_all_warnings_fixed();
+        }
+
+        // STDIN input has no backing file, so always print the result
+        // instead of writing anything to disk.
+        output.print_dry_run(&lines);
+        output.print_warnings(&fe, &warnings, 0);
+        output.print_total(warnings.len());
+        return Ok(());
+    }
+
     let files = dotenv_finder::FinderBuilder::new(current_dir)
         .with_paths(&opts.files)
         .exclude(&opts.exclude)
@@ -215,4 +260,4 @@ pub(crate) fn check_for_updates() {
 
         println!("\n{msg}\n{release_url}");
     }
-}
+                          }

--- a/dotenv-cli/tests/flags/mod.rs
+++ b/dotenv-cli/tests/flags/mod.rs
@@ -1,6 +1,7 @@
 mod backup;
 mod quiet;
 mod recursive;
+mod stdin;
 mod version;
 
 #[cfg(feature = "stub_check_version")]

--- a/dotenv-cli/tests/flags/stdin.rs
+++ b/dotenv-cli/tests/flags/stdin.rs
@@ -1,0 +1,84 @@
+use assert_cmd::Command;
+
+fn cmd() -> Command {
+    Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command from binary name")
+}
+
+#[test]
+fn check_stdin_with_warnings() {
+    let expected_output = "Checking .env\n\
+         .env:2 LowercaseKey: The foo key should be in uppercase\n\
+         \nFound 1 problem\n";
+
+    cmd()
+        .args(["check", "--stdin", "--skip-updates"])
+        .write_stdin("FOO=bar\nfoo=baz\n")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(expected_output);
+}
+
+#[test]
+fn check_stdin_without_warnings() {
+    let expected_output = "Checking .env\n\nNo problems found\n";
+
+    cmd()
+        .args(["check", "--stdin", "--skip-updates"])
+        .write_stdin("BAR=baz\nFOO=bar\n")
+        .assert()
+        .success()
+        .stdout(expected_output);
+}
+
+#[test]
+fn check_stdin_uses_custom_filename() {
+    let expected_output = "Checking .env.production\n\
+         .env.production:2 LowercaseKey: The foo key should be in uppercase\n\
+         \nFound 1 problem\n";
+
+    cmd()
+        .args([
+            "check",
+            "--stdin",
+            "--stdin-filename",
+            ".env.production",
+            "--skip-updates",
+        ])
+        .write_stdin("FOO=bar\nfoo=baz\n")
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(expected_output);
+}
+
+#[test]
+fn fix_stdin_prints_fixed_content_without_writing_to_disk() {
+    let output = cmd()
+        .args(["fix", "--stdin"])
+        .write_stdin("foo=bar\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).expect("utf8 output");
+
+    assert!(output.starts_with("Fixing .env\n"));
+    assert!(output.contains("Dry run - not changing any files on disk."));
+    assert!(output.contains("FOO=bar"));
+    assert!(output.contains(".env:1 LowercaseKey: The foo key should be in uppercase"));
+    assert!(output.trim_end().ends_with("All warnings are fixed. Total: 1"));
+}
+
+#[test]
+fn fix_stdin_without_warnings() {
+    let expected_output = "Fixing .env\n\nNo warnings found\n";
+
+    cmd()
+        .args(["fix", "--stdin"])
+        .write_stdin("FOO=bar\n")
+        .assert()
+        .success()
+        .stdout(expected_output);
+}

--- a/dotenv-finder/src/file.rs
+++ b/dotenv-finder/src/file.rs
@@ -57,6 +57,19 @@ impl FileEntry {
         let file_name = get_file_name(&path)?.to_string();
         let content = fs::read_to_string(&path).ok()?;
 
+        Some(Self::from_content(path, file_name, &content))
+    }
+
+    /// Builds a `(FileEntry, Vec<LineEntry>)` from content read on `STDIN`.
+    ///
+    /// `display_name` is used purely for display purposes (e.g. `--stdin-filename`)
+    /// and does not need to point at a real file on disk.
+    pub fn from_stdin(content: &str, display_name: String) -> (Self, Vec<LineEntry>) {
+        let path = PathBuf::from(&display_name);
+        Self::from_content(path, display_name, content)
+    }
+
+    fn from_content(path: PathBuf, file_name: String, content: &str) -> (Self, Vec<LineEntry>) {
         let mut lines: Vec<String> = content.lines().map(|line| line.to_string()).collect();
 
         // You must add a line, because [`Lines`] does not return the last empty row (excludes LF)
@@ -66,14 +79,14 @@ impl FileEntry {
 
         let lines = get_line_entries(lines);
 
-        Some((
+        (
             FileEntry {
                 path,
                 file_name,
                 total_lines: lines.len(),
             },
             lines,
-        ))
+        )
     }
 }
 
@@ -211,4 +224,4 @@ mod tests {
             )
         }
     }
-}
+            }


### PR DESCRIPTION
Closes #829

## What
Adds `--stdin` and `--stdin-filename` flags to both the `check` and `fix`
subcommands, allowing `.env` content to be piped in via STDIN instead of
requiring a file on disk.

This is useful for editor integrations (e.g. `any-lint` for VS Code) that
need to lint content on every keystroke without writing to disk first.

## How it works
- `check --stdin`: reads content from STDIN, checks it, prints warnings
  using `--stdin-filename` (default `.env`) as the display name.
- `fix --stdin`: same idea, but always behaves like `--dry-run` since
  there's no source file to write the result back to — it just prints
  the fixed content to stdout.
- `files` argument becomes optional when `--stdin` is passed.

## Testing
echo -e "FOO=bar\nfoo=baz" | dotenv-linter check --stdin
echo -e "FOO=bar\nfoo=baz" | dotenv-linter check --stdin --stdin-filename .env.production
echo -e "foo=bar" | dotenv-linter fix --stdin

All existing tests pass, plus 5 new tests covering the `--stdin` flag
(`dotenv-cli/tests/flags/stdin.rs`). `cargo clippy --all-targets` shows
no new warnings.

#### ✔ Checklist:

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).