### PR TITLE
fix: enhance unordered key sorting with comment delimited groups

### DIFF
--- a/dotenv-analyzer/src/fix/unordered_key.rs
+++ b/dotenv-analyzer/src/fix/unordered_key.rs
@@ -39,6 +39,8 @@ impl Fix for UnorderedKeyFixer {
             let mut controls_this_check = false;
             let mut is_off = false;
 
+            let is_group_boundary_comment = Self::is_group_boundary_comment(line);
+
             if let Some(comment) = line.get_comment().and_then(Comment::parse) {
                 is_control_comment = true;
                 controls_this_check = comment.checks.contains(&self.name());
@@ -67,6 +69,7 @@ impl Fix for UnorderedKeyFixer {
                 if line.is_empty()
                     || lines.len() == i + 1 // Is this the last line?
                     || is_control_comment
+                    || is_group_boundary_comment
                     || has_substitution_variables
                 {
                     if has_substitution_variables {
@@ -117,6 +120,15 @@ impl UnorderedKeyFixer {
         let sorted_lines: Vec<_> = slices.into_iter().flat_map(|s| s.iter().cloned()).collect();
 
         part.clone_from_slice(sorted_lines.as_slice());
+    }
+
+    fn is_group_boundary_comment(line: &LineEntry) -> bool {
+        let Some(comment) = line.get_comment() else {
+            return false;
+        };
+
+        let trimmed = comment.trim_start();
+        trimmed.starts_with("###>") || trimmed.starts_with("###<")
     }
 }
 
@@ -259,6 +271,43 @@ mod tests {
                 "\n",
                 "# end comment",
                 "\n",
+            ],
+        );
+    }
+
+    #[test]
+    fn comment_delimited_groups_test() {
+        let mut lines = get_lines(vec![
+            "ENV2=bbb",
+            "ENV1=aaa",
+            "",
+            "###> group1 ###",
+            "ENV4=ddd",
+            "ENV5=eee",
+            "ENV3=ccc",
+            "###< group1 ###",
+            "",
+            "ENV7=ggg",
+            "ENV6=fff",
+        ]);
+        let warning_lines = [2, 7, 11];
+
+        assert_eq!(Some(3), run_fixer(&warning_lines, &mut lines));
+
+        assert_lines(
+            &lines,
+            vec![
+                "ENV1=aaa",
+                "ENV2=bbb",
+                "",
+                "###> group1 ###",
+                "ENV3=ccc",
+                "ENV4=ddd",
+                "ENV5=eee",
+                "###< group1 ###",
+                "",
+                "ENV6=fff",
+                "ENV7=ggg",
             ],
         );
     }

--- a/dotenv-cli/tests/fixes/unordered_key.rs
+++ b/dotenv-cli/tests/fixes/unordered_key.rs
@@ -26,3 +26,28 @@ fn unordered_key() {
 
     testdir.close();
 }
+
+#[test]
+fn unordered_key_with_comment_delimited_groups() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(
+        ".env",
+        "ENV2=bbb\nENV1=aaa\n\n###> group1 ###\nENV4=ddd\nENV5=eee\nENV3=ccc\n###< group1 ###\n\nENV7=ggg\nENV6=fff\n",
+    );
+    let expected_output = fix_output(&[(
+        ".env",
+        &[
+            ".env:2 UnorderedKey: The ENV1 key should go before the ENV2 key",
+            ".env:7 UnorderedKey: The ENV3 key should go before the ENV4 key",
+            ".env:11 UnorderedKey: The ENV6 key should go before the ENV7 key",
+        ],
+    )]);
+    testdir.test_command_fix_success(expected_output);
+
+    assert_eq!(
+        testfile.contents().as_str(),
+        "ENV1=aaa\nENV2=bbb\n\n###> group1 ###\nENV3=ccc\nENV4=ddd\nENV5=eee\n###< group1 ###\n\nENV6=fff\nENV7=ggg\n",
+    );
+
+    testdir.close();
+}


### PR DESCRIPTION
## Summary
- keeps variables inside `###> ... ###` and `###< ... ###` comment-delimited groups during fix sorting
- sorts keys within each group without moving entries across group boundaries
- adds analyzer and CLI regression coverage for grouped env files

## Testing
- [x] cargo test -p dotenv-analyzer fix::unordered_key
- [x] cargo test -p dotenv-linter fixes::unordered_key
- [x] cargo fmt --check

Fixes #749