### PR TITLE
feat: support default and alternate substitutions

### DIFF
--- a/dotenv-analyzer/src/check/substitution_key.rs
+++ b/dotenv-analyzer/src/check/substitution_key.rs
@@ -33,22 +33,35 @@ impl Check for SubstitutionKeyChecker<'_> {
             let prefix = &value[..index];
             let raw_key = &value[index + 1..];
 
-            // Separate initial key from the rest
-            let (initial_key, rest) = raw_key
-                .find('$')
-                .map(|i| raw_key.split_at(i))
-                .unwrap_or_else(|| (raw_key, ""));
+            if is_escaped(prefix) {
+                value = raw_key;
+                continue;
+            }
 
-            let end_brace_index = initial_key.find('}');
-            let has_start_brace = initial_key.starts_with('{');
-            let has_end_brace = end_brace_index.is_some();
-            let is_incorrect_substitution = has_start_brace ^ has_end_brace
-                || end_brace_index
-                    .map(|i| &initial_key[1..i])
-                    .filter(|key| key.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_'))
-                    .is_some();
+            let (is_incorrect_substitution, rest) = if let Some(braced_key) =
+                raw_key.strip_prefix('{')
+            {
+                match braced_key.find('}') {
+                    Some(end_brace_index) => {
+                        let key = substitution_key_name(&braced_key[..end_brace_index]);
+                        let is_invalid_key = key.is_none_or(|key| {
+                            key.is_empty()
+                                || key.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                        });
+                        (is_invalid_key, &braced_key[(end_brace_index + 1)..])
+                    }
+                    None => (true, ""),
+                }
+            } else {
+                let (initial_key, rest) = raw_key
+                    .find('$')
+                    .map(|i| raw_key.split_at(i))
+                    .unwrap_or_else(|| (raw_key, ""));
 
-            if is_incorrect_substitution && !is_escaped(prefix) {
+                (initial_key.contains('}'), rest)
+            };
+
+            if is_incorrect_substitution {
                 return Some(Warning::new(
                     line.number,
                     self.name(),
@@ -66,6 +79,25 @@ impl Check for SubstitutionKeyChecker<'_> {
     }
 }
 
+fn substitution_key_name(key: &str) -> Option<&str> {
+    let mut operator_index = None;
+
+    for operator in [":-", ":+", ":=", ":?"] {
+        for (index, _) in key.match_indices(operator) {
+            if operator_index.is_some() {
+                return None;
+            }
+            operator_index = Some((index, operator));
+        }
+    }
+
+    match operator_index {
+        Some((index, ":-" | ":+")) => Some(&key[..index]),
+        Some(_) => None,
+        None => Some(key),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +111,10 @@ mod tests {
                 ("ABC=$BAR", None),
                 ("FOO=${BAR}", None),
                 ("FOO=\"$BAR\"", None),
+                ("FOO=${NODE_ENV:-development if not set}", None),
+                ("BAR=${CI:+only when running in CI}", None),
+                ("BAZ=${APP_ENV:-$NODE_ENV}", None),
+                ("FOO=${NODE_ENV:-development}${CI:+only}", None),
             ],
         );
     }
@@ -91,6 +127,18 @@ mod tests {
                 ("ABC=${BAR", Some("The ABC key is not assigned properly")),
                 ("FOO=${BAR!}", Some("The FOO key is not assigned properly")),
                 ("XYZ=$BAR}", Some("The XYZ key is not assigned properly")),
+                (
+                    "QUX=${NODE_ENV:development}",
+                    Some("The QUX key is not assigned properly"),
+                ),
+                (
+                    "BAZ=${SOME_VALUE--$$++???_END}",
+                    Some("The BAZ key is not assigned properly"),
+                ),
+                (
+                    "BUS=${CI:+only:?IS_UNSET:other}",
+                    Some("The BUS key is not assigned properly"),
+                ),
             ],
         );
     }

--- a/dotenv-cli/tests/checks/substitution_key.rs
+++ b/dotenv-cli/tests/checks/substitution_key.rs
@@ -8,6 +8,10 @@ fn correct_files() {
         "A=B\nFOO=\"$BAR\"\n",
         "FOO=$ABC{${BAR}\nBIZ=$FOO-$ABC\n",
         "ABC=\\${BAR\n",
+        "FOO=\"${NODE_ENV:-development if not set}\"\n",
+        "BAR=\"${CI:+only when running in CI}\"\n",
+        "BAZ=${APP_ENV:-$NODE_ENV}\n",
+        "FOO=${NODE_ENV:-development}${CI:+only}\n",
     ];
 
     for content in contents {
@@ -28,8 +32,17 @@ fn incorrect_files() {
         "A=${BAR!}FOO=B4\n",
         "TEST=$BAR}\n",
         "FOO=${ABC-$BAR}\n",
+        "BAR=${SOME_VALUE--$$++???_END}\n",
+        "BAZ=${CI:+only:?IS_UNSET:other}\n",
     ];
-    let expected = [(2, "FOO"), (1, "A"), (1, "TEST"), (1, "FOO")];
+    let expected = [
+        (2, "FOO"),
+        (1, "A"),
+        (1, "TEST"),
+        (1, "FOO"),
+        (1, "BAR"),
+        (1, "BAZ"),
+    ];
 
     for (i, content) in contents.iter().enumerate() {
         let testdir = TestDir::new();

--- a/dotenv-core/src/lib.rs
+++ b/dotenv-core/src/lib.rs
@@ -105,14 +105,20 @@ impl LineEntry {
             } else {
                 let (key, rest) = raw_key
                     .strip_prefix('{')
-                    .and_then(|raw_key| raw_key.find('}').map(|i| raw_key.split_at(i)))
+                    .and_then(|raw_key| {
+                        raw_key.find('}').and_then(|i| {
+                            let (raw_key, rest) = raw_key.split_at(i);
+                            substitution_key_name(raw_key).map(|key| (key, rest))
+                        })
+                    })
                     .or_else(|| {
                         raw_key
                             .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
                             .map(|i| raw_key.split_at(i))
                     })
                     .unwrap_or((raw_key, ""));
-                if key.is_empty() {
+                if key.is_empty() || key.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                {
                     return keys;
                 }
 
@@ -121,6 +127,25 @@ impl LineEntry {
             }
         }
         keys
+    }
+}
+
+fn substitution_key_name(key: &str) -> Option<&str> {
+    let mut operator_index = None;
+
+    for operator in [":-", ":+", ":=", ":?"] {
+        for (index, _) in key.match_indices(operator) {
+            if operator_index.is_some() {
+                return None;
+            }
+            operator_index = Some((index, operator));
+        }
+    }
+
+    match operator_index {
+        Some((index, ":-" | ":+")) => Some(&key[..index]),
+        Some(_) => None,
+        None => Some(key),
     }
 }
 
@@ -364,6 +389,30 @@ mod tests {
             assert_eq!(input.get_substitution_keys(), vec!["BAR"]);
 
             let input = line_entry(1, 1, "FOO=${BAR");
+            assert!(input.get_substitution_keys().is_empty());
+        }
+
+        #[test]
+        fn run_with_default_and_alternate_values() {
+            let input = line_entry(1, 1, "FOO=${NODE_ENV:-development if not set}");
+            assert_eq!(input.get_substitution_keys(), vec!["NODE_ENV"]);
+
+            let input = line_entry(1, 1, "BAR=${CI:+only when running in CI}");
+            assert_eq!(input.get_substitution_keys(), vec!["CI"]);
+
+            let input = line_entry(1, 1, "BAZ=${NODE_ENV:-development}${CI:+only}");
+            assert_eq!(input.get_substitution_keys(), vec!["NODE_ENV", "CI"]);
+        }
+
+        #[test]
+        fn run_with_invalid_default_and_alternate_values() {
+            let input = line_entry(1, 1, "FOO=${NODE_ENV:development}");
+            assert!(input.get_substitution_keys().is_empty());
+
+            let input = line_entry(1, 1, "BAR=${SOME_VALUE--$$++???_END}");
+            assert!(input.get_substitution_keys().is_empty());
+
+            let input = line_entry(1, 1, "BAZ=${CI:+only:?IS_UNSET:other}");
             assert!(input.get_substitution_keys().is_empty());
         }
 


### PR DESCRIPTION

## Summary
- accepts `${VAR:-default}` and `${VAR:+alternate}` syntax without `SubstitutionKey` errors
- keeps substitution dependency extraction based on the variable name before the `:-` or `:+` operator
- adds core, analyzer, and CLI regression coverage for both forms

## Testing
- [x] cargo test -p dotenv-core get_substitution_keys
- [x] cargo test -p dotenv-analyzer check::substitution_key
- [x] cargo test -p dotenv-linter checks::substitution_key
- [x] cargo fmt --check

Fixes #776
