### PR TITLE
test: skip the symlink test when Windows denies the privilege

### DIFF
--- a/dotenv-cli/tests/common/test_dir.rs
+++ b/dotenv-cli/tests/common/test_dir.rs
@@ -9,6 +9,12 @@ use tempfile::{TempDir, tempdir, tempdir_in};
 
 use crate::common::{test_file::TestFile, test_link::create_test_symlink};
 
+/// Windows only grants `SeCreateSymbolicLinkPrivilege` to administrators, or to
+/// any user when Developer Mode is enabled. Without it `symlink_dir` fails with
+/// `ERROR_PRIVILEGE_NOT_HELD`.
+#[cfg(windows)]
+const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
+
 /// Use to test commands in temporary directories
 pub struct TestDir {
     current_dir: TempDir,
@@ -61,10 +67,18 @@ impl TestDir {
         TestFile::new(&self.current_dir, name, contents)
     }
 
-    /// Create a new TestLink to a TestDir within the TestDir
-    pub fn create_symlink(&self, source_test_dir: &Self, name: &str) {
+    /// Create a new TestLink to a TestDir within the TestDir.
+    ///
+    /// Returns `false` when the platform refuses to create a symlink for an
+    /// unprivileged user, which is the default on Windows.
+    pub fn create_symlink(&self, source_test_dir: &Self, name: &str) -> bool {
         let dest = &self.current_dir.path().join(name);
-        create_test_symlink(&source_test_dir.current_dir, dest);
+        match create_test_symlink(&source_test_dir.current_dir, dest) {
+            Ok(()) => true,
+            #[cfg(windows)]
+            Err(err) if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD) => false,
+            Err(err) => panic!("create symlink: {err}"),
+        }
     }
 
     /// Get full path of TestDir as a &str

--- a/dotenv-cli/tests/common/test_link.rs
+++ b/dotenv-cli/tests/common/test_link.rs
@@ -1,13 +1,13 @@
-use std::{os, path::Path};
+use std::{io, os, path::Path};
 
 use tempfile::TempDir;
 
 /// Create a new symlink within a TempDir
 #[cfg(not(windows))]
-pub fn create_test_symlink(source_test_dir: &TempDir, dest: &Path) {
-    os::unix::fs::symlink(source_test_dir, dest).expect("create symlink");
+pub fn create_test_symlink(source_test_dir: &TempDir, dest: &Path) -> io::Result<()> {
+    os::unix::fs::symlink(source_test_dir, dest)
 }
 #[cfg(windows)]
-pub fn create_test_symlink(source_test_dir: &TempDir, dest: &Path) {
-    os::windows::fs::symlink_dir(source_test_dir, dest).expect("create symlink");
+pub fn create_test_symlink(source_test_dir: &TempDir, dest: &Path) -> io::Result<()> {
+    os::windows::fs::symlink_dir(source_test_dir, dest)
 }

--- a/dotenv-cli/tests/flags/recursive.rs
+++ b/dotenv-cli/tests/flags/recursive.rs
@@ -134,7 +134,10 @@ fn checks_nofollow_subdir_symlinks() {
         .to_str()
         .expect("multi-platform path to test .env file");
     // create a symbolic link to its containing directory
-    test_subdir.create_symlink(&test_subdir, "symlink");
+    if !test_subdir.create_symlink(&test_subdir, "symlink") {
+        eprintln!("skipping: creating a symlink needs elevation or Developer Mode on Windows");
+        return;
+    }
 
     let args = &["check", ".", "-r"];
     let expected_output = check_output(&[(


### PR DESCRIPTION
Closes #765.

## Problem

`cargo test` fails on Windows for anyone not running as administrator:

```
---- flags::recursive::checks_nofollow_subdir_symlinks stdout ----
thread 'flags::recursive::checks_nofollow_subdir_symlinks' panicked at tests/common/test_link.rs:
create symlink: Os { code: 1314, kind: Uncategorized, message: "A required privilege is not held by the client." }
```

Creating a directory symlink needs `SeCreateSymbolicLinkPrivilege`, which Windows grants only to administrators or to users who have turned on Developer Mode. A contributor on a default Windows install sees a red test run for a change they did not make.

## Fix

`create_test_symlink` returns the `io::Result` instead of unwrapping it, `TestDir::create_symlink` reports whether the link was created, and the test returns early when the OS refuses with `ERROR_PRIVILEGE_NOT_HELD` (1314).

The test is not disabled on Windows: it still runs wherever the privilege is held, which includes the GitHub Actions Windows runners, so CI coverage is unchanged. Any symlink error other than 1314 still panics.

## Verification

On Windows 11 with the privilege held:

```
cargo test --all-features
# 346 passed, 0 failed
cargo test -p dotenv-linter --test cli checks_nofollow_subdir_symlinks
# test flags::recursive::checks_nofollow_subdir_symlinks ... ok
```

Forcing `create_test_symlink` to return `io::Error::from_raw_os_error(1314)` to exercise the unprivileged path:

```
skipping: creating a symlink needs elevation or Developer Mode on Windows
test flags::recursive::checks_nofollow_subdir_symlinks ... ok
```

`cargo fmt --all` and `cargo clippy --all-targets --all-features` are clean (the one `unused import: command` warning is pre-existing on master).