### PR TITLE
fix: comment out every line of a multi-line value when fixing a duplicated key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixes
+
+- Comment out every line of a multi-line value when fixing a duplicated key
+
 ## [v4.0.0](https://github.com/dotenv-linter/dotenv-linter/releases/tag/v4.0.0) - 2025-10-18
 
 ### Features

--- a/dotenv-analyzer/src/fix/duplicated_key.rs
+++ b/dotenv-analyzer/src/fix/duplicated_key.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use dotenv_core::LineEntry;
 
 use super::Fix;
-use crate::{LintKind, comment::Comment};
+use crate::{LF, LintKind, comment::Comment};
 
 #[derive(Default)]
 pub(crate) struct DuplicatedKeyFixer {}
@@ -41,7 +41,12 @@ impl Fix for DuplicatedKeyFixer {
     }
 
     fn fix_line(&self, line: &mut LineEntry) -> Option<()> {
-        line.raw_string = format!("# {}", line.raw_string);
+        line.raw_string = line
+            .raw_string
+            .split(LF)
+            .map(|line| format!("# {line}"))
+            .collect::<Vec<String>>()
+            .join(LF);
 
         Some(())
     }
@@ -76,6 +81,22 @@ mod tests {
             &lines[..2],
             &[line_entry(1, 4, "FOO=BAR"), line_entry(2, 4, "Z=Y")]
         );
+    }
+
+    #[test]
+    fn fix_warnings_with_multiline_value() {
+        let fixer = DuplicatedKeyFixer::default();
+        let mut lines = vec![
+            line_entry(1, 5, "FOO=BAR"),
+            line_entry(2, 5, "FOO=\"multi\nline\nvalue\""),
+            line_entry(5, 5, "\n"),
+        ];
+        let warning_lines = [lines[1].number];
+
+        assert_eq!(Some(1), fixer.fix_warnings(&warning_lines, &mut lines));
+        assert_eq!("# FOO=\"multi\n# line\n# value\"", lines[1].raw_string);
+        assert_eq!("FOO=BAR", lines[0].raw_string);
+        assert_eq!("\n", lines[2].raw_string);
     }
 
     #[test]

--- a/dotenv-cli/tests/fixes/duplicated_key.rs
+++ b/dotenv-cli/tests/fixes/duplicated_key.rs
@@ -21,3 +21,30 @@ fn duplicated_key() {
 
     testdir.close();
 }
+
+#[test]
+fn duplicated_key_with_multiline_value() {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(
+        ".env",
+        "KEY=\"-----BEGIN-----\nabc\n-----END-----\"\n\
+         KEY=\"-----BEGIN-----\nxyz\n-----END-----\"\n",
+    );
+    let expected_output = fix_output(&[(
+        ".env",
+        &[".env:4 DuplicatedKey: The KEY key is duplicated"],
+    )]);
+
+    testdir.test_command_fix_success(expected_output);
+
+    assert_eq!(
+        testfile.contents().as_str(),
+        "KEY=\"-----BEGIN-----\nabc\n-----END-----\"\n\
+         # KEY=\"-----BEGIN-----\n# xyz\n# -----END-----\"\n"
+    );
+
+    testdir.test_command_success_with_args(
+        with_default_args(&["check", "."]),
+        check_output(&[(".env", &[])]),
+    );
+}


### PR DESCRIPTION
without the patch applied,

```plaintext
A="
1
"
A="
2
"
```

would be fixed to

```plaintext
A="
1
"
#A="
2
"
```

See the new tests for an MRE.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [X] Tests for the changes have been added (for bug fixes / features);
- [X] Docs have been added / updated on the [dotenv-linter.github.io](https://github.com/dotenv-linter/dotenv-linter.github.io) (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
